### PR TITLE
 Pre-commit config - Ruff, cmake & clang formaters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+ColumnLimit: 100
+IndentWidth: 4
+
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortFunctionsOnASingleLine: Empty
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+DerivePointerAlignment: false
+IncludeBlocks: Preserve
+IndentPPDirectives: BeforeHash
+PenaltyBreakAssignment: 21
+
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: false
+  AfterForeachMacros: false
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: false
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,6 @@
+with section("format"):  # noqa F821
+    line_width = 100
+    tab_size = 2
+    command_case = "lower"
+    max_subgroups_hwrap = 2
+    max_pargs_hwrap = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,48 @@
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.5
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+          - --exit-non-zero-on-fix
+      - id: ruff-format
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+      - id: cmake-lint
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.7
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]
+        args:
+          - --style=Google
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+      - id: check-ast
       - id: check-case-conflict
+      - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
       - id: check-toml
       - id: check-xml
+      - id: check-yaml
       - id: debug-statements
       - id: destroyed-symlinks
       - id: detect-private-key
       - id: end-of-file-fixer
+      - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: pretty-format-json
       - id: trailing-whitespace
-      - id: check-yaml
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: clang-format
         types_or: [c++, c]
         args:
-          - --style=Google
+          - --style=file
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -5,71 +5,51 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(HW_IF_INCLUDE_DEPENDS
-  fmt
-  hardware_interface
-  pluginlib
-  rclcpp
-  rclcpp_lifecycle
-  rcpputils
-)
+set(HW_IF_INCLUDE_DEPENDS fmt hardware_interface pluginlib rclcpp
+                          rclcpp_lifecycle rcpputils)
 
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
+foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
+  find_package(${dependency} REQUIRED)
 endforeach()
 
-add_library(${PROJECT_NAME}
-    SHARED
-    hardware/src/hande_hardware_interface.cpp
-)
+add_library(${PROJECT_NAME} SHARED hardware/src/hande_hardware_interface.cpp)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
-target_include_directories(robotiq_hande_driver PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hardware/include>
-  $<INSTALL_INTERFACE:include>
-)
-ament_target_dependencies(
-  ${PROJECT_NAME} PUBLIC
-  ${HW_IF_INCLUDE_DEPENDS}
-)
+target_include_directories(
+  robotiq_hande_driver
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hardware/include>
+         $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC ${HW_IF_INCLUDE_DEPENDS})
 
-pluginlib_export_plugin_description_file(hardware_interface ros2_control_plugin.xml)
+pluginlib_export_plugin_description_file(hardware_interface
+                                         ros2_control_plugin.xml)
+
+install(DIRECTORY hardware/include/ DESTINATION include/)
+install(DIRECTORY bringup DESTINATION share/${PROJECT_NAME})
 
 install(
-  DIRECTORY hardware/include/
-  DESTINATION include/
-)
-install(
-  DIRECTORY bringup
-  DESTINATION share/${PROJECT_NAME}
-)
-
-
-install(TARGETS ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+  RUNTIME DESTINATION bin)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   # find_package(ament_cmake_pytest REQUIRED)
   find_package(hardware_interface REQUIRED)
 
-  ament_add_gmock(test_load_hw_interface
-    test/test_load_hw_interface.cpp
-  )
+  ament_add_gmock(test_load_hw_interface test/test_load_hw_interface.cpp)
   target_link_libraries(test_load_hw_interface ${PROJECT_NAME})
 
-  # TODO: investigate
-  # ament_add_pytest_test(example_7_urdf_xacro test/test_urdf_xacro.py)
-  # ament_add_pytest_test(view_example_7_launch test/test_view_robot_launch.py)
-  # ament_add_pytest_test(run_example_7_launch test/test_r6bot_controller_launch.py)
+  # TODO: investigate ament_add_pytest_test(example_7_urdf_xacro
+  # test/test_urdf_xacro.py) ament_add_pytest_test(view_example_7_launch
+  # test/test_view_robot_launch.py) ament_add_pytest_test(run_example_7_launch
+  # test/test_r6bot_controller_launch.py)
 endif()
 
-## EXPORTS
+# EXPORTS
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(${HW_IF_INCLUDE_DEPENDS})
 ament_package()

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_driver)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 set(HW_IF_INCLUDE_DEPENDS fmt hardware_interface pluginlib rclcpp

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_driver)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  # TODO(issue#5) Fix warnings to enable the -Werror flag
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 set(HW_IF_INCLUDE_DEPENDS

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -5,8 +5,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
-set(HW_IF_INCLUDE_DEPENDS fmt hardware_interface pluginlib rclcpp
-                          rclcpp_lifecycle rcpputils)
+set(HW_IF_INCLUDE_DEPENDS
+    fmt
+    hardware_interface
+    pluginlib
+    rclcpp
+    rclcpp_lifecycle
+    rcpputils)
 
 find_package(ament_cmake REQUIRED)
 foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
@@ -17,13 +22,11 @@ add_library(${PROJECT_NAME} SHARED hardware/src/hande_hardware_interface.cpp)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(
-  robotiq_hande_driver
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hardware/include>
-         $<INSTALL_INTERFACE:include>)
+  robotiq_hande_driver PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hardware/include>
+                              $<INSTALL_INTERFACE:include>)
 ament_target_dependencies(${PROJECT_NAME} PUBLIC ${HW_IF_INCLUDE_DEPENDS})
 
-pluginlib_export_plugin_description_file(hardware_interface
-                                         ros2_control_plugin.xml)
+pluginlib_export_plugin_description_file(hardware_interface ros2_control_plugin.xml)
 
 install(DIRECTORY hardware/include/ DESTINATION include/)
 install(DIRECTORY bringup DESTINATION share/${PROJECT_NAME})
@@ -43,10 +46,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_load_hw_interface test/test_load_hw_interface.cpp)
   target_link_libraries(test_load_hw_interface ${PROJECT_NAME})
 
-  # TODO: investigate ament_add_pytest_test(example_7_urdf_xacro
-  # test/test_urdf_xacro.py) ament_add_pytest_test(view_example_7_launch
-  # test/test_view_robot_launch.py) ament_add_pytest_test(run_example_7_launch
-  # test/test_r6bot_controller_launch.py)
+  # TODO: investigate ament_add_pytest_test(example_7_urdf_xacro test/test_urdf_xacro.py)
+  # ament_add_pytest_test(view_example_7_launch test/test_view_robot_launch.py)
+  # ament_add_pytest_test(run_example_7_launch test/test_r6bot_controller_launch.py)
 endif()
 
 # EXPORTS

--- a/robotiq_hande_driver/bringup/launch/gripper_controller_preview.launch.py
+++ b/robotiq_hande_driver/bringup/launch/gripper_controller_preview.launch.py
@@ -48,9 +48,8 @@ def generate_launch_description():
 
 
 def launch_setup(context: LaunchContext) -> list[IncludeLaunchDescription]:
-
     # tf_prefix is implicitly used in robot_state_publisher (in URDF substitution)
-    tf_prefix = LaunchConfiguration("tf_prefix", default="")
+    tf_prefix = LaunchConfiguration("tf_prefix", default="")  # noqa: F841
 
     return [
         preapre_control_node(),
@@ -105,7 +104,8 @@ def preapre_control_node() -> Node:
 
 
 def prepare_robot_state_publisher_node() -> Node:
-    tf_prefix = LaunchConfiguration("tf_prefix", default="")
+    # tf_prefix is implicitly used in ParameterValue()
+    tf_prefix = LaunchConfiguration("tf_prefix", default="")  # noqa: F841
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
 
     robot_description_str = Command(

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -1,9 +1,9 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__HANDE_HARDWARE_INTERFACE_HPP_
 #define ROBOTIQ_HANDE_DRIVER__HANDE_HARDWARE_INTERFACE_HPP_
 
-#include <string>
 #include <hardware_interface/system_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 
 namespace robotiq_hande_driver {
 
@@ -12,37 +12,43 @@ namespace rlccp_lc = rclcpp_lifecycle;
 
 constexpr int LEFT_FINGER_JOINT_ID = 0;
 
-class RobotiqHandeHardwareInterface : public HWI::SystemInterface
-{
-public:
-    RobotiqHandeHardwareInterface();
+class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
+ public:
+  RobotiqHandeHardwareInterface();
 
-    HWI::CallbackReturn on_init(const HWI::HardwareInfo& info) override;
-    HWI::CallbackReturn on_configure(const rlccp_lc::State& previous_state) override;
-    HWI::CallbackReturn on_cleanup(const rlccp_lc::State& previous_state) override;
-    std::vector<HWI::StateInterface> export_state_interfaces() override;
-    std::vector<HWI::CommandInterface> export_command_interfaces() override;
+  HWI::CallbackReturn on_init(const HWI::HardwareInfo& info) override;
+  HWI::CallbackReturn on_configure(
+      const rlccp_lc::State& previous_state) override;
+  HWI::CallbackReturn on_cleanup(
+      const rlccp_lc::State& previous_state) override;
+  std::vector<HWI::StateInterface> export_state_interfaces() override;
+  std::vector<HWI::CommandInterface> export_command_interfaces() override;
 
-    HWI::CallbackReturn on_activate(const rlccp_lc::State& previous_state) override;
-    HWI::CallbackReturn on_deactivate(const rlccp_lc::State& previous_state) override;
+  HWI::CallbackReturn on_activate(
+      const rlccp_lc::State& previous_state) override;
+  HWI::CallbackReturn on_deactivate(
+      const rlccp_lc::State& previous_state) override;
 
-    HWI::CallbackReturn on_shutdown(const rlccp_lc::State& previous_state) override;
-    HWI::CallbackReturn on_error(const rlccp_lc::State& previous_state) override;
+  HWI::CallbackReturn on_shutdown(
+      const rlccp_lc::State& previous_state) override;
+  HWI::CallbackReturn on_error(const rlccp_lc::State& previous_state) override;
 
-    HWI::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
-    HWI::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+  HWI::return_type read(const rclcpp::Time& time,
+                        const rclcpp::Duration& period) override;
+  HWI::return_type write(const rclcpp::Time& time,
+                         const rclcpp::Duration& period) override;
 
-    rclcpp::Logger get_logger() const { return *logger_; }
+  rclcpp::Logger get_logger() const { return *logger_; }
 
-private:
-    //TODO(modbus integration): composition of the modbus communication
-    std::shared_ptr<rclcpp::Logger> logger_;
+ private:
+  // TODO(modbus integration): composition of the modbus communication
+  std::shared_ptr<rclcpp::Logger> logger_;
 
-    std::string tty_port_;
-    double state_position_;
-    double state_velocity_;
-    double cmd_position_;
+  std::string tty_port_;
+  double state_position_;
+  double state_velocity_;
+  double cmd_position_;
 };
 
-} // namespace robotiq_hande_driver
+}  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__HANDE_HARDWARE_INTERFACE_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -13,41 +13,36 @@ namespace rlccp_lc = rclcpp_lifecycle;
 constexpr int LEFT_FINGER_JOINT_ID = 0;
 
 class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
- public:
-  RobotiqHandeHardwareInterface();
+   public:
+    RobotiqHandeHardwareInterface();
 
-  HWI::CallbackReturn on_init(const HWI::HardwareInfo& info) override;
-  HWI::CallbackReturn on_configure(
-      const rlccp_lc::State& previous_state) override;
-  HWI::CallbackReturn on_cleanup(
-      const rlccp_lc::State& previous_state) override;
-  std::vector<HWI::StateInterface> export_state_interfaces() override;
-  std::vector<HWI::CommandInterface> export_command_interfaces() override;
+    HWI::CallbackReturn on_init(const HWI::HardwareInfo& info) override;
+    HWI::CallbackReturn on_configure(const rlccp_lc::State& previous_state) override;
+    HWI::CallbackReturn on_cleanup(const rlccp_lc::State& previous_state) override;
+    std::vector<HWI::StateInterface> export_state_interfaces() override;
+    std::vector<HWI::CommandInterface> export_command_interfaces() override;
 
-  HWI::CallbackReturn on_activate(
-      const rlccp_lc::State& previous_state) override;
-  HWI::CallbackReturn on_deactivate(
-      const rlccp_lc::State& previous_state) override;
+    HWI::CallbackReturn on_activate(const rlccp_lc::State& previous_state) override;
+    HWI::CallbackReturn on_deactivate(const rlccp_lc::State& previous_state) override;
 
-  HWI::CallbackReturn on_shutdown(
-      const rlccp_lc::State& previous_state) override;
-  HWI::CallbackReturn on_error(const rlccp_lc::State& previous_state) override;
+    HWI::CallbackReturn on_shutdown(const rlccp_lc::State& previous_state) override;
+    HWI::CallbackReturn on_error(const rlccp_lc::State& previous_state) override;
 
-  HWI::return_type read(const rclcpp::Time& time,
-                        const rclcpp::Duration& period) override;
-  HWI::return_type write(const rclcpp::Time& time,
-                         const rclcpp::Duration& period) override;
+    HWI::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+    HWI::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
-  rclcpp::Logger get_logger() const { return *logger_; }
+    rclcpp::Logger get_logger() const {
+        return *logger_;
+    }
 
- private:
-  // TODO(modbus integration): composition of the modbus communication
-  std::shared_ptr<rclcpp::Logger> logger_;
+   private:
+    // TODO(modbus integration): composition of the modbus communication
+    std::shared_ptr<rclcpp::Logger> logger_;
 
-  std::string tty_port_;
-  double state_position_;
-  double state_velocity_;
-  double cmd_position_;
+    std::string tty_port_;
+    double state_position_;
+    double state_velocity_;
+    double cmd_position_;
 };
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -7,97 +7,110 @@ namespace robotiq_hande_driver {
 
 RobotiqHandeHardwareInterface::RobotiqHandeHardwareInterface() {}
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareInfo& info) {
-    if (HWI::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
-        return HWI::CallbackReturn::ERROR;
-    }
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(
+    const HWI::HardwareInfo& info) {
+  if (HWI::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+    return HWI::CallbackReturn::ERROR;
+  }
 
-    state_position_ = 0.025;
-    state_velocity_ = 0.0;
-    cmd_position_ = 0.025;
-    tty_port_ = info_.hardware_parameters["tty"];
+  state_position_ = 0.025;
+  state_velocity_ = 0.0;
+  cmd_position_ = 0.025;
+  tty_port_ = info_.hardware_parameters["tty"];
 
-    logger_ = std::make_shared<rclcpp::Logger>(
-    rclcpp::get_logger("controller_manager.resource_manager.hardware_component.system.RobotiqHandeHardwareInterface"));
+  logger_ = std::make_shared<rclcpp::Logger>(
+      rclcpp::get_logger("controller_manager.resource_manager.hardware_"
+                         "component.system.RobotiqHandeHardwareInterface"));
 
-    //TODO(modbus integration): Set parameters for the modbus communication
+  // TODO(modbus integration): Set parameters for the modbus communication
 
-    RCLCPP_INFO(get_logger(), "Initialized ModbusRTU for %s", tty_port_.c_str());
-    return HWI::CallbackReturn::SUCCESS;
+  RCLCPP_INFO(get_logger(), "Initialized ModbusRTU for %s", tty_port_.c_str());
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Initialize the ModbusRTU communication session
-    RCLCPP_INFO(get_logger(), "configure()");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Initialize the ModbusRTU communication session
+  RCLCPP_INFO(get_logger(), "configure()");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Deinitalize the ModbusRTU session
-    RCLCPP_INFO(get_logger(), "cleanup()");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Deinitalize the ModbusRTU session
+  RCLCPP_INFO(get_logger(), "cleanup()");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-std::vector<HWI::StateInterface> RobotiqHandeHardwareInterface::export_state_interfaces() {
-    std::vector<HWI::StateInterface> state_interfaces;
+std::vector<HWI::StateInterface>
+RobotiqHandeHardwareInterface::export_state_interfaces() {
+  std::vector<HWI::StateInterface> state_interfaces;
 
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[LEFT_FINGER_JOINT_ID].name, hardware_interface::HW_IF_POSITION, &state_position_));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[LEFT_FINGER_JOINT_ID].name, hardware_interface::HW_IF_VELOCITY, &state_velocity_));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[LEFT_FINGER_JOINT_ID].name,
+      hardware_interface::HW_IF_POSITION, &state_position_));
+  state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[LEFT_FINGER_JOINT_ID].name,
+      hardware_interface::HW_IF_VELOCITY, &state_velocity_));
 
-    RCLCPP_INFO(get_logger(), "export_state_interfaces()");
-    return state_interfaces;
+  RCLCPP_INFO(get_logger(), "export_state_interfaces()");
+  return state_interfaces;
 }
 
-std::vector<HWI::CommandInterface> RobotiqHandeHardwareInterface::export_command_interfaces() {
-    std::vector<hardware_interface::CommandInterface> command_interfaces;
+std::vector<HWI::CommandInterface>
+RobotiqHandeHardwareInterface::export_command_interfaces() {
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
 
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[LEFT_FINGER_JOINT_ID].name, hardware_interface::HW_IF_POSITION, &cmd_position_));
+  command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[LEFT_FINGER_JOINT_ID].name,
+      hardware_interface::HW_IF_POSITION, &cmd_position_));
 
-    RCLCPP_INFO(get_logger(), "export_command_interfaces()");
-    return command_interfaces;
+  RCLCPP_INFO(get_logger(), "export_command_interfaces()");
+  return command_interfaces;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Power on the gripper (activation)
-    RCLCPP_INFO(get_logger(), "activate()");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Power on the gripper (activation)
+  RCLCPP_INFO(get_logger(), "activate()");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Deactiavte the gripper (set the reset flag)
-    RCLCPP_INFO(get_logger(), "deactivate()");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Deactiavte the gripper (set the reset flag)
+  RCLCPP_INFO(get_logger(), "deactivate()");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_shutdown(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Deactivate the gripper, deinitalize the modbus RTU session,
-    RCLCPP_INFO(get_logger(), "shutdown()");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_shutdown(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Deactivate the gripper, deinitalize the modbus
+  // RTU session,
+  RCLCPP_INFO(get_logger(), "shutdown()");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(const rlccp_lc::State& /*previous_state*/){
-    //TODO(modbus integration): Placeholder for error handling
-    RCLCPP_INFO(get_logger(), "Handled error");
-    return HWI::CallbackReturn::SUCCESS;
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(
+    const rlccp_lc::State& /*previous_state*/) {
+  // TODO(modbus integration): Placeholder for error handling
+  RCLCPP_INFO(get_logger(), "Handled error");
+  return HWI::CallbackReturn::SUCCESS;
 }
 
-HWI::return_type RobotiqHandeHardwareInterface::read(const rclcpp::Time& /*time*/,
-                                                     const rclcpp::Duration& /*period*/) {
-    //TODO(modbus integration): data = driver_->receive_data();
-    return hardware_interface::return_type::OK;
+HWI::return_type RobotiqHandeHardwareInterface::read(
+    const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
+  // TODO(modbus integration): data = driver_->receive_data();
+  return hardware_interface::return_type::OK;
 }
-HWI::return_type RobotiqHandeHardwareInterface::write(const rclcpp::Time& /*time*/,
-                                                      const rclcpp::Duration& /*period*/) {
-    //TODO(modbus integration): driver_->send_data(cmd_position_);
-    return hardware_interface::return_type::OK;
+HWI::return_type RobotiqHandeHardwareInterface::write(
+    const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
+  // TODO(modbus integration): driver_->send_data(cmd_position_);
+  return hardware_interface::return_type::OK;
 }
 
-
-} // namespace robotiq_hande_driver
+}  // namespace robotiq_hande_driver
 
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(
-  robotiq_hande_driver::RobotiqHandeHardwareInterface, hardware_interface::SystemInterface)
+PLUGINLIB_EXPORT_CLASS(robotiq_hande_driver::RobotiqHandeHardwareInterface,
+                       hardware_interface::SystemInterface)

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -7,110 +7,110 @@ namespace robotiq_hande_driver {
 
 RobotiqHandeHardwareInterface::RobotiqHandeHardwareInterface() {}
 
-HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(
-    const HWI::HardwareInfo& info) {
-  if (HWI::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
-    return HWI::CallbackReturn::ERROR;
-  }
+HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareInfo& info) {
+    if(HWI::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+        return HWI::CallbackReturn::ERROR;
+    }
 
-  state_position_ = 0.025;
-  state_velocity_ = 0.0;
-  cmd_position_ = 0.025;
-  tty_port_ = info_.hardware_parameters["tty"];
+    state_position_ = 0.025;
+    state_velocity_ = 0.0;
+    cmd_position_ = 0.025;
+    tty_port_ = info_.hardware_parameters["tty"];
 
-  logger_ = std::make_shared<rclcpp::Logger>(
-      rclcpp::get_logger("controller_manager.resource_manager.hardware_"
-                         "component.system.RobotiqHandeHardwareInterface"));
+    logger_ = std::make_shared<rclcpp::Logger>(
+        rclcpp::get_logger("controller_manager.resource_manager.hardware_"
+                           "component.system.RobotiqHandeHardwareInterface"));
 
-  // TODO(modbus integration): Set parameters for the modbus communication
+    // TODO(modbus integration): Set parameters for the modbus communication
 
-  RCLCPP_INFO(get_logger(), "Initialized ModbusRTU for %s", tty_port_.c_str());
-  return HWI::CallbackReturn::SUCCESS;
+    RCLCPP_INFO(get_logger(), "Initialized ModbusRTU for %s", tty_port_.c_str());
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Initialize the ModbusRTU communication session
-  RCLCPP_INFO(get_logger(), "configure()");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Initialize the ModbusRTU communication session
+    RCLCPP_INFO(get_logger(), "configure()");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Deinitalize the ModbusRTU session
-  RCLCPP_INFO(get_logger(), "cleanup()");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Deinitalize the ModbusRTU session
+    RCLCPP_INFO(get_logger(), "cleanup()");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
-std::vector<HWI::StateInterface>
-RobotiqHandeHardwareInterface::export_state_interfaces() {
-  std::vector<HWI::StateInterface> state_interfaces;
+std::vector<HWI::StateInterface> RobotiqHandeHardwareInterface::export_state_interfaces() {
+    std::vector<HWI::StateInterface> state_interfaces;
 
-  state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[LEFT_FINGER_JOINT_ID].name,
-      hardware_interface::HW_IF_POSITION, &state_position_));
-  state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[LEFT_FINGER_JOINT_ID].name,
-      hardware_interface::HW_IF_VELOCITY, &state_velocity_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[LEFT_FINGER_JOINT_ID].name,
+        hardware_interface::HW_IF_POSITION,
+        &state_position_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[LEFT_FINGER_JOINT_ID].name,
+        hardware_interface::HW_IF_VELOCITY,
+        &state_velocity_));
 
-  RCLCPP_INFO(get_logger(), "export_state_interfaces()");
-  return state_interfaces;
+    RCLCPP_INFO(get_logger(), "export_state_interfaces()");
+    return state_interfaces;
 }
 
-std::vector<HWI::CommandInterface>
-RobotiqHandeHardwareInterface::export_command_interfaces() {
-  std::vector<hardware_interface::CommandInterface> command_interfaces;
+std::vector<HWI::CommandInterface> RobotiqHandeHardwareInterface::export_command_interfaces() {
+    std::vector<hardware_interface::CommandInterface> command_interfaces;
 
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[LEFT_FINGER_JOINT_ID].name,
-      hardware_interface::HW_IF_POSITION, &cmd_position_));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[LEFT_FINGER_JOINT_ID].name,
+        hardware_interface::HW_IF_POSITION,
+        &cmd_position_));
 
-  RCLCPP_INFO(get_logger(), "export_command_interfaces()");
-  return command_interfaces;
+    RCLCPP_INFO(get_logger(), "export_command_interfaces()");
+    return command_interfaces;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Power on the gripper (activation)
-  RCLCPP_INFO(get_logger(), "activate()");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Power on the gripper (activation)
+    RCLCPP_INFO(get_logger(), "activate()");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Deactiavte the gripper (set the reset flag)
-  RCLCPP_INFO(get_logger(), "deactivate()");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Deactiavte the gripper (set the reset flag)
+    RCLCPP_INFO(get_logger(), "deactivate()");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_shutdown(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Deactivate the gripper, deinitalize the modbus
-  // RTU session,
-  RCLCPP_INFO(get_logger(), "shutdown()");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Deactivate the gripper, deinitalize the modbus
+    // RTU session,
+    RCLCPP_INFO(get_logger(), "shutdown()");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(
     const rlccp_lc::State& /*previous_state*/) {
-  // TODO(modbus integration): Placeholder for error handling
-  RCLCPP_INFO(get_logger(), "Handled error");
-  return HWI::CallbackReturn::SUCCESS;
+    // TODO(modbus integration): Placeholder for error handling
+    RCLCPP_INFO(get_logger(), "Handled error");
+    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::return_type RobotiqHandeHardwareInterface::read(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-  // TODO(modbus integration): data = driver_->receive_data();
-  return hardware_interface::return_type::OK;
+    // TODO(modbus integration): data = driver_->receive_data();
+    return hardware_interface::return_type::OK;
 }
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-  // TODO(modbus integration): driver_->send_data(cmd_position_);
-  return hardware_interface::return_type::OK;
+    // TODO(modbus integration): driver_->send_data(cmd_position_);
+    return hardware_interface::return_type::OK;
 }
 
 }  // namespace robotiq_hande_driver
 
 #include "pluginlib/class_list_macros.hpp"
-PLUGINLIB_EXPORT_CLASS(robotiq_hande_driver::RobotiqHandeHardwareInterface,
-                       hardware_interface::SystemInterface)
+PLUGINLIB_EXPORT_CLASS(
+    robotiq_hande_driver::RobotiqHandeHardwareInterface, hardware_interface::SystemInterface)

--- a/robotiq_hande_driver/test/test_load_hw_interface.cpp
+++ b/robotiq_hande_driver/test/test_load_hw_interface.cpp
@@ -14,16 +14,15 @@
 
 namespace {
 const auto TIME = rclcpp::Time(0);
-const auto PERIOD =
-    rclcpp::Duration::from_seconds(0.1);  // 0.1 seconds for easier math
+const auto PERIOD = rclcpp::Duration::from_seconds(0.1);  // 0.1 seconds for easier math
 const auto COMPARE_DELTA = 0.0001;
 }  // namespace
 
 class TestHWInterface : public ::testing::Test {
- protected:
-  void SetUp() override {
-    hw_system_gripper_1dof_ =
-        R"(
+   protected:
+    void SetUp() override {
+        hw_system_gripper_1dof_ =
+            R"(
             <ros2_control name="HandeGripperExample" type="system">
                 <hardware>
                     <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
@@ -37,9 +36,9 @@ class TestHWInterface : public ::testing::Test {
                 </joint>
             </ros2_control>
         )";
-  }
+    }
 
-  std::string hw_system_gripper_1dof_;
+    std::string hw_system_gripper_1dof_;
 };
 
 // Forward declaration
@@ -48,20 +47,18 @@ class ResourceStorage;
 }
 
 class TestableResourceManager : public hardware_interface::ResourceManager {
- public:
-  friend TestHWInterface;
+   public:
+    friend TestHWInterface;
 
-  TestableResourceManager() : hardware_interface::ResourceManager() {}
+    TestableResourceManager() : hardware_interface::ResourceManager() {}
 
-  TestableResourceManager(const std::string& urdf,
-                          bool validate_interfaces = true,
-                          bool activate_all = false)
-      : hardware_interface::ResourceManager(urdf, validate_interfaces,
-                                            activate_all) {}
+    TestableResourceManager(
+        const std::string& urdf, bool validate_interfaces = true, bool activate_all = false)
+        : hardware_interface::ResourceManager(urdf, validate_interfaces, activate_all) {}
 };
 
 TEST_F(TestHWInterface, load_robotiq_hande_hardware_interface) {
-  auto urdf = ros2_control_test_assets::urdf_head + hw_system_gripper_1dof_ +
-              ros2_control_test_assets::urdf_tail;
-  ASSERT_NO_THROW(TestableResourceManager rm(urdf));
+    auto urdf = ros2_control_test_assets::urdf_head + hw_system_gripper_1dof_
+                + ros2_control_test_assets::urdf_tail;
+    ASSERT_NO_THROW(TestableResourceManager rm(urdf));
 }

--- a/robotiq_hande_driver/test/test_load_hw_interface.cpp
+++ b/robotiq_hande_driver/test/test_load_hw_interface.cpp
@@ -12,18 +12,16 @@
 #include "ros2_control_test_assets/components_urdfs.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
-namespace
-{
+namespace {
 const auto TIME = rclcpp::Time(0);
-const auto PERIOD = rclcpp::Duration::from_seconds(0.1);  // 0.1 seconds for easier math
+const auto PERIOD =
+    rclcpp::Duration::from_seconds(0.1);  // 0.1 seconds for easier math
 const auto COMPARE_DELTA = 0.0001;
 }  // namespace
 
-class TestHWInterface : public ::testing::Test
-{
-protected:
-  void SetUp() override
-  {
+class TestHWInterface : public ::testing::Test {
+ protected:
+  void SetUp() override {
     hw_system_gripper_1dof_ =
         R"(
             <ros2_control name="HandeGripperExample" type="system">
@@ -45,27 +43,24 @@ protected:
 };
 
 // Forward declaration
-namespace hardware_interface
-{
+namespace hardware_interface {
 class ResourceStorage;
 }
 
-class TestableResourceManager : public hardware_interface::ResourceManager
-{
-public:
+class TestableResourceManager : public hardware_interface::ResourceManager {
+ public:
   friend TestHWInterface;
 
   TestableResourceManager() : hardware_interface::ResourceManager() {}
 
-  TestableResourceManager(
-    const std::string & urdf, bool validate_interfaces = true, bool activate_all = false)
-  : hardware_interface::ResourceManager(urdf, validate_interfaces, activate_all)
-  {
-  }
+  TestableResourceManager(const std::string& urdf,
+                          bool validate_interfaces = true,
+                          bool activate_all = false)
+      : hardware_interface::ResourceManager(urdf, validate_interfaces,
+                                            activate_all) {}
 };
 
-TEST_F(TestHWInterface, load_robotiq_hande_hardware_interface)
-{
+TEST_F(TestHWInterface, load_robotiq_hande_hardware_interface) {
   auto urdf = ros2_control_test_assets::urdf_head + hw_system_gripper_1dof_ +
               ros2_control_test_assets::urdf_tail;
   ASSERT_NO_THROW(TestableResourceManager rm(urdf));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Inspired by pre-config config proposed in machines-in-motion/mim_solvers/pull/45 , this PR introduces such convenience to this repository: C++, Python and CMakeLists formatters.

>[!WARNING]
>It also adds the `-Werror` flag to the compiler. (But resulted in issue #5)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* The lack of auto-formatters for C++ and CMakeLists.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually by running `pre-commit run --all-files -v`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [ ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ ] All automated checks have passed.

---
Clickup task: [8697wj13v](https://app.clickup.com/t/8697wj13v)
