### PR TITLE
ADD: reconnecting to modbus on configure

### DIFF
--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Reconnecting to modbus on configure
 * [PR-7](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/7) - Integration of ModbusRTU communication with ros2_control Hardware Interface
 * [PR-2](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/2) - ModbusRTU communication
 * [PR-2](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/2) - Protocol abstraction
@@ -21,5 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Modbus connection check always fails
 
 ### Security

--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -23,6 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Modbus connection check always fails
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Fixed an issue where the Modbus connection check always failed.
 
 ### Security

--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Reconnecting to modbus on configure
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/11) - Added automatic reconnection to Modbus during configuration.
 * [PR-7](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/7) - Integration of ModbusRTU communication with ros2_control Hardware Interface
 * [PR-2](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/2) - ModbusRTU communication
 * [PR-2](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/2) - Protocol abstraction

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -136,7 +136,7 @@ class Communication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void read_write_registers() {
+    int read_write_registers() {
         /**
          * @brief Read and write modbus registers at once
          *
@@ -147,11 +147,13 @@ class Communication {
          * @param int read_addr
          * @param int read_nb
          * @param uint16_t *dest
-         * @return int >0 on success
+         * @return int > -1 on success
          * @note The status should be checked to verify successful execution. An exception is thrown
          * if communication issues occur.
          */
-        modbus_write_and_read_registers(
+        int result;
+
+        result = modbus_write_and_read_registers(
             mb_,
             GRIPPER_INPUT_FIRST_REG,
             OUTPUT_REGISTER_WORD_LENGTH,
@@ -159,6 +161,8 @@ class Communication {
             GRIPPER_OUTPUT_FIRST_REG,
             INPUT_REGISTER_WORD_LENGTH,
             reinterpret_cast<uint16_t*>(input_bytes_));
+
+        return result;
     };
 
     /**

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -147,7 +147,7 @@ class Communication {
          * @param int read_addr
          * @param int read_nb
          * @param uint16_t *dest
-         * @return int > -1 on success
+         * @return int FAILURE_MODBUS on failure, nonnegative value for success
          * @note The status should be checked to verify successful execution. An exception is thrown
          * if communication issues occur.
          */

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -7,12 +7,11 @@ namespace robotiq_hande_driver {
 Communication::Communication() : input_bytes_{}, output_bytes_{} {}
 
 int Communication::connect() {
-    uint16_t activation_status[1] = {0x0000};
     int result;
 
     modbus_connect(mb_);
 
-    result = modbus_read_registers(mb_, GRIPPER_OUTPUT_FIRST_REG, 1, activation_status);
+    result = read_write_registers();
 
     return result;
 }

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -74,6 +74,14 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     int result;
 
     RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
+    RCLCPP_DEBUG(
+        get_logger(),
+        "Connecting to tty:%s, baudrate:%d, parity:%c, data_bits:%d, stop_bit:%d",
+        tty_port_.c_str(),
+        baudrate_,
+        parity_,
+        data_bits_,
+        stop_bit_);
 
     result = gripper_driver_.configure();
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -71,7 +71,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
-    int result;
+    int result = FAILURE_MODBUS;
 
     RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
     RCLCPP_DEBUG(
@@ -83,24 +83,24 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
         data_bits_,
         stop_bit_);
 
-
     result = gripper_driver_.configure();
 
-    for (int iter = 0; result == FAILURE_MODBUS && iter < RECONNECT_MAX_ITER; iter++) {
-        RCLCPP_DEBUG(get_logger(), "Reconfiguring Hand-E Gripper attempt: %d; result: %d", iter, result);
-    
+    for(int iter = 0; result == FAILURE_MODBUS && iter < RECONNECT_MAX_ITER; iter++) {
+        RCLCPP_DEBUG(
+            get_logger(), "Reconfiguring Hand-E Gripper attempt: %d; result: %d", iter, result);
+
         wait_100ms();
         wait_100ms();
-        
+
         gripper_driver_.cleanup();
         result = gripper_driver_.configure();
     }
-    
-    if(iter == RECONNECT_MAX_ITER) {
+
+    if(result == FAILURE_MODBUS) {
         RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
         return HWI::CallbackReturn::FAILURE;
     }
-    
+
     RCLCPP_INFO(get_logger(), "Connected");
     return HWI::CallbackReturn::SUCCESS;
 }

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -72,7 +72,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
     int result;
-    int iter = 0;
 
     RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -83,7 +83,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
         data_bits_,
         stop_bit_);
 
-    result = gripper_driver_.configure();
 
     while(result == FAILURE_MODBUS) {
         wait_100ms();

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -7,6 +7,7 @@ namespace robotiq_hande_driver {
 
 static constexpr auto THROTTLE_1000_MS = 1000;
 static constexpr auto ACTIVATION_MAX_ITER = 100;
+static constexpr auto RECONNECT_MAX_ITER = 10;
 inline void wait_100ms() {
     usleep(100 * 1000);
 }
@@ -71,23 +72,28 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
     int result;
+    int iter = 0;
 
-    RCLCPP_INFO(
-        get_logger(),
-        "Connecting to tty:%s, baudrate:%d, parity:%c, data_bits:%d, stop_bit:%d",
-        tty_port_.c_str(),
-        baudrate_,
-        parity_,
-        data_bits_,
-        stop_bit_);
+    RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
+
     result = gripper_driver_.configure();
 
-    // TODO(issue#10) Modbus connection check always fails
-    // if(result == FAILURE_MODBUS) {
-    //     RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
-    //     return HWI::CallbackReturn::FAILURE;
-    // }
-    RCLCPP_INFO(get_logger(), "Configured Hand-E Gripper: %d", result);
+    while(result == FAILURE_MODBUS) {
+        wait_100ms();
+        wait_100ms();
+
+        gripper_driver_.cleanup();
+        result = gripper_driver_.configure();
+        RCLCPP_DEBUG(
+            get_logger(), "Reconfiguring Hand-E Gripper iter: %d; result: %d", iter, result);
+
+        iter++;
+        if(iter == RECONNECT_MAX_ITER) {
+            RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
+            return HWI::CallbackReturn::FAILURE;
+        }
+    }
+
     return HWI::CallbackReturn::SUCCESS;
 }
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -103,7 +103,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     
     RCLCPP_INFO(get_logger(), "Connected");
     return HWI::CallbackReturn::SUCCESS;
-    return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -84,22 +84,25 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
         stop_bit_);
 
 
-    while(result == FAILURE_MODBUS) {
-        wait_100ms();
-        wait_100ms();
+    result = gripper_driver_.configure();
 
+    for (int iter = 0; result == FAILURE_MODBUS && iter < RECONNECT_MAX_ITER; iter++) {
+        RCLCPP_DEBUG(get_logger(), "Reconfiguring Hand-E Gripper attempt: %d; result: %d", iter, result);
+    
+        wait_100ms();
+        wait_100ms();
+        
         gripper_driver_.cleanup();
         result = gripper_driver_.configure();
-        RCLCPP_DEBUG(
-            get_logger(), "Reconfiguring Hand-E Gripper iter: %d; result: %d", iter, result);
-
-        iter++;
-        if(iter == RECONNECT_MAX_ITER) {
-            RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
-            return HWI::CallbackReturn::FAILURE;
-        }
     }
-
+    
+    if(iter == RECONNECT_MAX_ITER) {
+        RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
+        return HWI::CallbackReturn::FAILURE;
+    }
+    
+    RCLCPP_INFO(get_logger(), "Connected");
+    return HWI::CallbackReturn::SUCCESS;
     return HWI::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
## Description
This PR adds to configuration procedure retries to establish connection to modbus. Initially it was meant to be placed in on_error handler, but so far we always need 2-3 retries so we treat it as regular behaviour and the loop is in the on_configure part. 

## Motivation and context
Not always serial port is opened before controller hardware layer wants to initiate connection to modbus. This results in error in connection and further processing.

Closes #10 

## How has this been tested?
Tested manually with [robotiq_hande_driver](https://github.com/AGH-CEAI/robotiq_hande_driver/) package (on real hardware).


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [86986zx0u](https://app.clickup.com/t/86986zx0u)
