### PR TITLE
Refactor - Multithread modbus communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Before build, change the hardcoded parameters in the beginning of the `robotiq_h
 
 To run test:
 ```bash
-cd cd ~/ceai_ws/src/robotiq_hande_driver/build/robotiq_hande_driver/
+cd ~/ceai/ros_ws/build/robotiq_hande_driver
 ./communication_test
 ```
 

--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -8,10 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [PR-21](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/21) - Added:
+  * `SocatManager` for managing the external `socat` process.
+  * Added colored logging.
+  * Introduced 4 new params for URDFs:
+    * `frequency_hz` (int) to control the amount of sleep rate in new thread
+    * `create_socat_tty` (bool) to create a virtual serial port,
+    * `ip_adress` and `port` to configure the creation of virtual serial port with `socat`,
+
 ### Changed
+
+* [PR-21](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/21) - Refactored the modbus communication to use multithreads:
+  * Renamed `application.hpp/cpp` to `hande_gripper.hpp/cpp`.
+  * Changed plain arrays `uint8_t bytes_[]` into `std::array<uint8_t, *>`.
+  * Moved all logic from the `communication.cpp/hpp` to `protocol_logic.cpp/hpp`.
+  * Moved all non-trivial definitions from `*.hpp`s to `*.cpp`s.
+  * Moved from C-like functions to C++ ones (e.g. to `chrono` and `thread` instead of `usleep()`).
+  * Encapsulated whole `Communication` config into `CommunicationConfig` struct.
+  *  renamed `tty` param to `tty_port` for better clarity.
+
 ### Deprecated
+
 ### Removed
 ### Fixed
+
+* [PR-21](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/21) - Fixed:
+  * Fixed integration with - UR's RTDE communication protocol ([aegis_ros#38](https://github.com/AGH-CEAI/aegis_ros/issues/38)).
+  * Re-enabled the `-Werror` flag #5.
+  * Fixed typos with wrong values in  `GRIPPER_OUTPUT_FIRST_REG`  and `GRIPPER_INPUT_FIRST_REG`.
+
 ### Security
 
 ## [0.1.0] - 2025-03-13

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HW_IF_INCLUDE_DEPENDS
     rcpputils)
 
 find_package(ament_cmake REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 
 foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
   find_package(${dependency} REQUIRED)

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_driver)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  # TODO(issue#5) Fix warnings to enable the -Werror flag
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 include(FindPkgConfig)

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -24,8 +24,12 @@ foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
 endforeach()
 
 add_library(
-  ${PROJECT_NAME} SHARED hardware/src/hande_hardware_interface.cpp hardware/src/hande_gripper.cpp
-                         hardware/src/communication.cpp hardware/src/protocol_logic.cpp)
+  ${PROJECT_NAME} SHARED
+  hardware/src/hande_hardware_interface.cpp
+  hardware/src/hande_gripper.cpp
+  hardware/src/communication.cpp
+  hardware/src/protocol_logic.cpp
+  hardware/src/socat_manager.cpp)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEPENDS})
 

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -19,7 +19,6 @@ set(HW_IF_INCLUDE_DEPENDS
     rcpputils)
 
 find_package(ament_cmake REQUIRED)
-find_package(behaviortree_cpp REQUIRED)
 
 foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
   find_package(${dependency} REQUIRED)

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
 endforeach()
 
 add_library(
-  ${PROJECT_NAME} SHARED hardware/src/hande_hardware_interface.cpp hardware/src/application.cpp
+  ${PROJECT_NAME} SHARED hardware/src/hande_hardware_interface.cpp hardware/src/hande_gripper.cpp
                          hardware/src/communication.cpp hardware/src/protocol_logic.cpp)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEPENDS})

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/application.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/application.hpp
@@ -159,7 +159,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    const Status& get_status() const;
+    Status get_status() const;
 
     /**
      * @brief Retrieves the gripper fault status.
@@ -169,7 +169,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    const FaultStatus& get_fault_status() const;
+    FaultStatus get_fault_status() const;
 
     /**
      * @brief Retrieves the requested position of the gripper.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/application.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/application.hpp
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include "protocol_logic.hpp"
+#include "robotiq_hande_driver/protocol_logic.hpp"
 
 namespace robotiq_hande_driver {
 
@@ -33,7 +33,7 @@ class GripperApplication {
 
     GripperApplication();
 
-    ~GripperApplication() {};
+    ~GripperApplication() = default;
 
     /**
      * @brief Initializes driver parameters.
@@ -47,8 +47,6 @@ class GripperApplication {
      * @param stop_bit Modbus serial stopbit.
      * @param slave_id Modbus slave id.
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void initialize(
         double gripper_position_min,
@@ -58,12 +56,7 @@ class GripperApplication {
         char parity,
         int data_bits,
         int stop_bit,
-        int slave_id) {
-        gripper_position_min_ = gripper_position_min;
-        gripper_position_max_ = gripper_position_max;
-        gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;
-        protocol_logic_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
-    };
+        int slave_id);
 
     /**
      * @brief Configures driver session.
@@ -71,37 +64,23 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    int configure() {
-        int result;
-
-        result = protocol_logic_.configure();
-
-        return result;
-    };
+    int configure();
 
     /**
      * @brief Deinitializes driver.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void cleanup() {
-        protocol_logic_.cleanup();
-    };
+    void cleanup();
 
     /**
      * @brief Stops the gripper movement.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void stop() {
-        protocol_logic_.stop();
-    };
+    void stop();
 
     /**
      * @brief Resets the gripper by deactivating and reactivating it.
@@ -111,9 +90,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void reset() {
-        protocol_logic_.reset();
-    };
+    void reset();
 
     /**
      *  Emergency auto-release, gripper fingers are slowly opened, reactivation necessary
@@ -123,9 +100,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void auto_release() {
-        protocol_logic_.auto_release();
-    };
+    void auto_release();
 
     /**
      * @brief Activates the gripper, making it ready for use.
@@ -134,9 +109,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void activate() {
-        protocol_logic_.activate();
-    };
+    void activate();
 
     /**
      * @brief Deactivates the gripper.
@@ -146,9 +119,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void deactivate() {
-        protocol_logic_.reset();
-    };
+    void deactivate();
 
     /**
      * @brief Deactivates the gripper.
@@ -158,10 +129,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void shutdown() {
-        deactivate();
-        cleanup();
-    };
+    void shutdown();
 
     /**
      * @brief Opens the gripper.
@@ -171,9 +139,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void open() {
-        set_position(gripper_position_max_);
-    };
+    void open();
 
     /**
      * @brief Closes the gripper.
@@ -183,9 +149,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void close() {
-        set_position(gripper_position_min_);
-    };
+    void close();
 
     /**
      * @brief Retrieves the gripper status.
@@ -195,9 +159,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    Status get_status() {
-        return status_;
-    };
+    const Status& get_status() const;
 
     /**
      * @brief Retrieves the gripper fault status.
@@ -207,9 +169,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    FaultStatus get_fault_status() {
-        return fault_status_;
-    };
+    const FaultStatus& get_fault_status() const;
 
     /**
      * @brief Retrieves the requested position of the gripper.
@@ -219,9 +179,7 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    double get_requested_position() {
-        return requested_position_;
-    };
+    double get_requested_position() const;
 
     /**
      * @brief Retrieves the actual position of the gripper.
@@ -231,25 +189,15 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    double get_position() {
-        return position_;
-    };
+    double get_position() const;
 
     /**
      * @brief Moves the gripper to the requested position.
      *
      * @param position The target position in meters.
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void set_position(double position, double force = 1.0) {
-        uint8_t scaled_force = static_cast<uint8_t>(force * MAX_FORCE);
-        protocol_logic_.go_to(
-            (uint8_t)((gripper_position_max_ - position) / gripper_postion_step_),
-            MAX_SPEED,
-            scaled_force);
-    };
+    void set_position(double position, double force = 1.0);
 
     /**
      * @brief Retrieves the electric current drawn by the gripper.
@@ -259,17 +207,13 @@ class GripperApplication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    double get_current() {
-        return current_;
-    };
+    double get_current() const;
 
     /**
      * @brief Reads gripper data.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void read();
 
@@ -278,12 +222,8 @@ class GripperApplication {
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void write() {
-        protocol_logic_.refresh_registers();
-    };
+    void write();
 
    private:
     /**

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -1,12 +1,13 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
-#include <vector>
 
 #include <modbus/modbus.h>
 
@@ -29,6 +30,7 @@ enum class OutputBytes : uint8_t {
 };
 static constexpr auto NUM_OF_OUTPUT_BYTES = static_cast<size_t>(OutputBytes::BYTES_MAX);
 static constexpr auto OUTPUT_REGISTER_WORD_LENGTH = static_cast<uint>(OutputBytes::BYTES_MAX) / 2;
+using OutputBuffer = std::array<uint8_t, NUM_OF_OUTPUT_BYTES>;
 
 enum class InputBytes : uint8_t {
     RESERVED_1 = 0u,
@@ -41,44 +43,27 @@ enum class InputBytes : uint8_t {
 };
 static constexpr auto NUM_OF_INPUT_BYTES = static_cast<size_t>(OutputBytes::BYTES_MAX);
 static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes::BYTES_MAX) / 2;
+using InputBuffer = std::array<uint8_t, NUM_OF_INPUT_BYTES>;
 
 /**
- * @brief An auxialry struct to hold and interpret the registers data.
+ * @brief Struct to hold all Modbus Communication class config
+ * @param tty_port Modbus virtual port.
+ * @param baudrate Modbus serial baudrate.
+ * @param parity Modbus serial parity.
+ * @param data_bits Modbus serial data bits.
+ * @param stop_bit Modbus serial stopbit.
+ * @param slave_id Modbus slave id.
+ * @param th_sleep_rate The Modbus communication sleep rate.
  */
-// struct OutputRegisters {
-//     // TODO add if for checking the reg range
-//     uint8_t get(OutputBytes reg) {
-//         std::lock_guard<std::mutex> lock(mtx_);
-//         return regs_[reg];
-//     }
-
-//     void set(OutputBytes reg, uint8_t val) {
-//         std::lock_guard<std::mutex> lock(mtx_);
-//         regs_[reg] = val;
-//     }
-
-//     uint8_t regs_[NUM_OF_OUTPUT_BYTES];
-
-//    private:
-//     mutable std::mutex mtx_;
-// };
-// struct InputRegisters {
-//     // TODO add if for checking the reg range
-//     uint8_t get(InputBytes reg) {
-//         std::lock_guard<std::mutex> lock(mtx_);
-//         return regs_[reg];
-//     }
-
-//     void set(InputBytes reg, uint8_t val) {
-//         std::lock_guard<std::mutex> lock(mtx_);
-//         regs_[reg] = val;
-//     }
-
-//     uint8_t regs_[NUM_OF_INPUT_BYTES];
-
-//    private:
-//     mutable std::mutex mtx_;
-// };
+struct CommunicationConfig {
+    const std::string tty_port;
+    const int baudrate;
+    const char parity;
+    const int data_bits;
+    const int stop_bit;
+    const int slave_id;
+    const std::chrono::milliseconds th_sleep_rate;
+};
 
 /**
  * @brief This class contains low level gripper commands and status
@@ -92,23 +77,10 @@ class Communication {
     /**
      * @brief Initializes driver parameters.
      *
-     * @param tty_port Modbus virtual port.
-     * @param baudrate Modbus serial baudrate.
-     * @param parity Modbus serial parity.
-     * @param data_bits Modbus serial data bits.
-     * @param stop_bit Modbus serial stopbit.
-     * @param slave_id Modbus slave id.
+     * @param cfg Communication config
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void initialize(
-        const std::string& tty_port,
-        int baudrate,
-        char parity,
-        int data_bits,
-        int stop_bit,
-        int slave_id);
+    void initialize(const CommunicationConfig& cfg);
 
     /**
      * @brief Reads and writes input/output registers at once.
@@ -160,7 +132,7 @@ class Communication {
      * @param none
      * @return Copy of the input bytes.
      */
-    std::array<uint8_t, NUM_OF_INPUT_BYTES> get_input_bytes() const;
+    InputBuffer get_input_bytes() const;
 
     /**
      * @brief Sets all of the output bytes values.
@@ -168,24 +140,18 @@ class Communication {
      * @param vals The values to be set.
      * @return none
      */
-    void set_output_bytes(const std::array<uint8_t, NUM_OF_OUTPUT_BYTES>& vals);
+    void set_output_bytes(const OutputBuffer& vals);
 
    private:
-    std::string tty_port_;
-    int baudrate_;
-    char parity_;
-    int data_bits_;
-    int stop_bit_;
-    int slave_id_;
-
+    CommunicationConfig cfg_;
     modbus_t* mb_;
 
-    std::array<uint8_t, NUM_OF_INPUT_BYTES> input_bytes_;
-    std::array<uint8_t, NUM_OF_OUTPUT_BYTES> output_bytes_;
+    InputBuffer input_bytes_;
+    OutputBuffer output_bytes_;
 
     mutable std::mutex mtx_;
-    std::atomic<bool> bg_comm_enabled_;
-    std::optional<std::thread> bg_comm_;
+    std::atomic<bool> th_comm_enabled_;
+    std::optional<std::thread> th_comm_;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -48,9 +48,7 @@ class Communication {
    public:
     Communication();
 
-    ~Communication() {
-        cleanup();
-    };
+    ~Communication();
 
     /**
      * @brief Initializes driver parameters.
@@ -71,63 +69,16 @@ class Communication {
         char parity,
         int data_bits,
         int stop_bit,
-        int slave_id) {
-        tty_port_ = tty_port.c_str();
-        baudrate_ = baudrate;
-        parity_ = parity;
-        data_bits_ = data_bits;
-        stop_bit_ = stop_bit;
-        slave_id_ = slave_id;
-    };
+        int slave_id);
 
     /**
      * @brief Reads and writes input/output registers at once.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
+     * @note Used in external thread.
      */
-    void read_write_registers() {
-        /**
-         * @brief Read and write modbus registers at once
-         *
-         * @param modbus_t *ctx
-         * @param int write_addr
-         * @param int write_nb
-         * @param uint16_t *src
-         * @param int read_addr
-         * @param int read_nb
-         * @param uint16_t *dest
-         * @return int FAILURE_MODBUS on failure, nonnegative value for success
-         * @note The status should be checked to verify successful execution. An exception is thrown
-         * if communication issues occur.
-         */
-        // int result;
-
-        while(running) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-            for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
-                output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
-            }
-
-            modbus_write_and_read_registers(
-                mb_,
-                GRIPPER_INPUT_FIRST_REG,
-                OUTPUT_REGISTER_WORD_LENGTH,
-                reinterpret_cast<uint16_t*>(output_bytes_modbus_),
-                GRIPPER_OUTPUT_FIRST_REG,
-                INPUT_REGISTER_WORD_LENGTH,
-                reinterpret_cast<uint16_t*>(input_bytes_modbus_));
-
-            for(size_t i = 0; i < NUM_OF_INPUT_BYTES; ++i) {
-                input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
-            }
-        }
-
-        // return result;
-    };
+    void read_write_registers();
 
     /**
      * @brief Initializes communication layer.
@@ -137,43 +88,22 @@ class Communication {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    int configure() {
-        int result;
-
-        mb_ = modbus_new_rtu(tty_port_, baudrate_, parity_, data_bits_, stop_bit_);
-        modbus_set_slave(mb_, slave_id_);
-        modbus_set_debug(mb_, DEBUG_MODBUS);
-        result = connect();
-
-        my_thread.emplace(&Communication::read_write_registers, this);
-
-        return result;
-    };
+    int configure();
 
     /**
      * @brief Deinitializes communication layer.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void cleanup() {
-        if(my_thread && my_thread->joinable()) {
-            my_thread->join();
-        }
-
-        disconnect();
-        modbus_free(mb_);
-    };
+    void cleanup();
 
     /**
      * @brief Connects to the gripper using Modbus RTU and a virtual socket.
      *
      * @param none
      * @return connection status code.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
+     * @note The status should be checked to verify successful execution.
      */
     int connect();
 
@@ -182,39 +112,24 @@ class Communication {
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void disconnect() {
-        modbus_close(mb_);
-    };
+    void disconnect();
 
     /**
      * @brief Sets output bytes to zeros.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void clear_output_bytes() {
-        // memset(output_bytes_, 0, sizeof(output_bytes_));
-        for(size_t i = 0; i < static_cast<size_t>(OutputBytes::BYTES_MAX); ++i) {
-            output_bytes_[i].store(0, std::memory_order_relaxed);
-        }
-    };
+    void clear_output_bytes();
 
     /**
      * @brief Retrieves the input byte value at the specified index.
      *
      * @param index The InputBytes byte index.
      * @return Requested byte value.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    uint8_t get_input_byte(InputBytes index) {
-        return input_bytes_[static_cast<uint>(index)].load(std::memory_order_relaxed);
-    };
+    uint8_t get_input_byte(InputBytes index);
 
     /**
      * @brief Sets the output byte value at the specified index.
@@ -222,12 +137,8 @@ class Communication {
      * @param index OutputBytes byte index
      * @param value The value to be set.
      * @return none
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void set_output_byte(OutputBytes index, uint8_t value) {
-        output_bytes_[static_cast<uint>(index)].store(value, std::memory_order_relaxed);
-    };
+    void set_output_byte(OutputBytes index, uint8_t value);
 
     /**
      * @brief Sets the n-th bit of the action request byte.
@@ -236,15 +147,7 @@ class Communication {
      * @param value The boolean value to set for the bit.
      * @return None.
      */
-    void write_action_bit(uint8_t position_bit, bool value) {
-        output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)].store(
-            bit_set_to(
-                output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)].load(
-                    std::memory_order_relaxed),
-                position_bit,
-                value),
-            std::memory_order_relaxed);
-    };
+    void write_action_bit(uint8_t position_bit, bool value);
 
     /**
      * @brief Sets the n-th bit of a number to the specified boolean value.
@@ -254,11 +157,7 @@ class Communication {
      * @param x The boolean value to set the bit to.
      * @return The modified number with the n-th bit set to the specified value.
      */
-    uint bit_set_to(uint value, uint n, bool x) {
-        uint reset_n_bit = ~(1u << n);
-        uint set_n_bit = static_cast<uint>(x) << n;
-        return (value & reset_n_bit) | set_n_bit;
-    };
+    uint bit_set_to(uint value, uint n, bool x);
 
    private:
     const char* tty_port_;
@@ -270,14 +169,14 @@ class Communication {
 
     modbus_t* mb_;
 
-    uint8_t input_bytes_modbus_[static_cast<size_t>(InputBytes::BYTES_MAX)];
-    uint8_t output_bytes_modbus_[static_cast<size_t>(OutputBytes::BYTES_MAX)];
+    uint8_t input_bytes_modbus_[NUM_OF_INPUT_BYTES];
+    uint8_t output_bytes_modbus_[NUM_OF_OUTPUT_BYTES];
 
-    std::atomic<uint8_t> input_bytes_[static_cast<size_t>(InputBytes::BYTES_MAX)];
-    std::atomic<uint8_t> output_bytes_[static_cast<size_t>(OutputBytes::BYTES_MAX)];
+    std::atomic<uint8_t> input_bytes_[NUM_OF_INPUT_BYTES];
+    std::atomic<uint8_t> output_bytes_[NUM_OF_OUTPUT_BYTES];
 
-    std::atomic<bool> running{true};
-    std::optional<std::thread> my_thread;
+    std::atomic<bool> bg_comm_enabled_{true};
+    std::optional<std::thread> bg_comm_;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -72,9 +72,6 @@ struct CommunicationConfig {
  * @brief This class wrappers the low level serial modubus communication with the gripper
  */
 class Communication {
-    static constexpr auto DEBUG_MODBUS = false;
-    static constexpr auto FAILURE_MODBUS = -1;
-
    public:
     Communication();
 
@@ -124,6 +121,9 @@ class Communication {
    private:
     CommunicationConfig cfg_;
     modbus_t* mb_;
+
+    static constexpr auto DEBUG_MODBUS = false;
+    static constexpr auto FAILURE_MODBUS = -1;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -45,40 +45,40 @@ static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes:
 /**
  * @brief An auxialry struct to hold and interpret the registers data.
  */
-struct OutputRegisters {
-    // TODO add if for checking the reg range
-    uint8_t get(OutputBytes reg) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        return regs_[reg];
-    }
+// struct OutputRegisters {
+//     // TODO add if for checking the reg range
+//     uint8_t get(OutputBytes reg) {
+//         std::lock_guard<std::mutex> lock(mtx_);
+//         return regs_[reg];
+//     }
 
-    void set(OutputBytes reg, uint8_t val) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        regs_[reg] = val;
-    }
+//     void set(OutputBytes reg, uint8_t val) {
+//         std::lock_guard<std::mutex> lock(mtx_);
+//         regs_[reg] = val;
+//     }
 
-    uint8_t regs_[NUM_OF_OUTPUT_BYTES];
+//     uint8_t regs_[NUM_OF_OUTPUT_BYTES];
 
-   private:
-    mutable std::mutex mtx_;
-};
-struct InputRegisters {
-    // TODO add if for checking the reg range
-    uint8_t get(InputBytes reg) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        return regs_[reg];
-    }
+//    private:
+//     mutable std::mutex mtx_;
+// };
+// struct InputRegisters {
+//     // TODO add if for checking the reg range
+//     uint8_t get(InputBytes reg) {
+//         std::lock_guard<std::mutex> lock(mtx_);
+//         return regs_[reg];
+//     }
 
-    void set(InputBytes reg, uint8_t val) {
-        std::lock_guard<std::mutex> lock(mtx_);
-        regs_[reg] = val;
-    }
+//     void set(InputBytes reg, uint8_t val) {
+//         std::lock_guard<std::mutex> lock(mtx_);
+//         regs_[reg] = val;
+//     }
 
-    uint8_t regs_[NUM_OF_INPUT_BYTES];
+//     uint8_t regs_[NUM_OF_INPUT_BYTES];
 
-   private:
-    mutable std::mutex mtx_;
-};
+//    private:
+//     mutable std::mutex mtx_;
+// };
 
 /**
  * @brief This class contains low level gripper commands and status

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -26,6 +26,7 @@ enum class OutputBytes : uint8_t {
     SPEED,
     BYTES_MAX
 };
+static constexpr auto NUM_OF_OUTPUT_BYTES = static_cast<size_t>(OutputBytes::BYTES_MAX);
 static constexpr auto OUTPUT_REGISTER_WORD_LENGTH = static_cast<uint>(OutputBytes::BYTES_MAX) / 2;
 
 enum class InputBytes : uint8_t {
@@ -37,6 +38,7 @@ enum class InputBytes : uint8_t {
     POSITION,
     BYTES_MAX
 };
+static constexpr auto NUM_OF_INPUT_BYTES = static_cast<size_t>(OutputBytes::BYTES_MAX);
 static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes::BYTES_MAX) / 2;
 
 /**
@@ -104,10 +106,9 @@ class Communication {
         // int result;
 
         while(running) {
-            // sleep for 100ms
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-            for(size_t i = 0; i < static_cast<size_t>(OutputBytes::BYTES_MAX); ++i) {
+            for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
                 output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
             }
 
@@ -120,7 +121,7 @@ class Communication {
                 INPUT_REGISTER_WORD_LENGTH,
                 reinterpret_cast<uint16_t*>(input_bytes_modbus_));
 
-            for(size_t i = 0; i < static_cast<size_t>(InputBytes::BYTES_MAX); ++i) {
+            for(size_t i = 0; i < NUM_OF_INPUT_BYTES; ++i) {
                 input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
             }
         }

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -43,7 +43,6 @@ static constexpr auto NUM_OF_INPUT_BYTES = static_cast<size_t>(OutputBytes::BYTE
 static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes::BYTES_MAX) / 2;
 using InputBuffer = std::array<uint8_t, NUM_OF_INPUT_BYTES>;
 
-// Define a custom exception by inheriting from std::exception
 class CommunicationError : public std::exception {
    private:
     std::string message_;
@@ -57,14 +56,14 @@ class CommunicationError : public std::exception {
 };
 
 /**
- * @brief Struct to hold all Modbus Communication class config
+ * @brief Struct to hold all modbus communication class config
  * @param tty_port Modbus virtual port.
  * @param baudrate Modbus serial baudrate.
  * @param parity Modbus serial parity.
  * @param data_bits Modbus serial data bits.
  * @param stop_bit Modbus serial stopbit.
  * @param slave_id Modbus slave id.
- * @param th_sleep_rate The Modbus communication sleep rate.
+ * @param th_sleep_rate Sleep rate for modbus communication.
  */
 struct CommunicationConfig {
     std::string tty_port;
@@ -77,7 +76,7 @@ struct CommunicationConfig {
 };
 
 /**
- * @brief This class contains low level gripper commands and status
+ * @brief This class wrappers the low level serial modubus communication with the gripper
  */
 class Communication {
     static constexpr auto DEBUG_MODBUS = false;
@@ -92,56 +91,39 @@ class Communication {
      * @brief Initializes driver parameters.
      *
      * @param cfg Communication config
-     * @return None.
      */
     void initialize(const CommunicationConfig& cfg);
 
     /**
      * @brief Reads and writes input/output registers at once.
      *
-     * @param none
-     * @return None.
      * @note Used in external thread.
      */
     void read_write_registers();
 
     /**
      * @brief Initializes communication layer.
-     *
-     * @param none
-     * @return int Connection status code.
      */
     void configure();
 
     /**
      * @brief Deinitializes communication layer.
-     *
-     * @param none
-     * @return None.
      */
     void cleanup();
 
     /**
      * @brief Connects to the gripper using Modbus RTU and a virtual socket.
-     *
-     * @param none
-     * @return connection status code.
-     * @note The status should be checked to verify successful execution.
      */
     void connect();
 
     /**
      * @brief Disconnects from the gripper using Modbus RTU and a virtual socket.
-     *
-     * @param none
-     * @return None.
      */
     void disconnect();
 
     /**
      * @brief Retrieves all of the input bytes values.
      *
-     * @param none
      * @return Copy of the input bytes.
      */
     InputBuffer get_input_bytes() const;
@@ -150,7 +132,6 @@ class Communication {
      * @brief Sets all of the output bytes values.
      *
      * @param vals The values to be set.
-     * @return none
      */
     void set_output_bytes(const OutputBuffer& vals);
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <exception>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -12,9 +13,6 @@
 #include <modbus/modbus.h>
 
 namespace robotiq_hande_driver {
-
-static constexpr auto DEBUG_MODBUS = false;
-static constexpr auto FAILURE_MODBUS = -1;
 
 static constexpr uint16_t GRIPPER_OUTPUT_FIRST_REG = 0x07D0;
 static constexpr uint16_t GRIPPER_INPUT_FIRST_REG = 0x03E8;
@@ -45,6 +43,19 @@ static constexpr auto NUM_OF_INPUT_BYTES = static_cast<size_t>(OutputBytes::BYTE
 static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes::BYTES_MAX) / 2;
 using InputBuffer = std::array<uint8_t, NUM_OF_INPUT_BYTES>;
 
+// Define a custom exception by inheriting from std::exception
+class CommunicationError : public std::exception {
+   private:
+    std::string message_;
+
+   public:
+    CommunicationError(const std::string& msg) : message_(msg) {}
+
+    const char* what() const noexcept override {
+        return message_.c_str();
+    }
+};
+
 /**
  * @brief Struct to hold all Modbus Communication class config
  * @param tty_port Modbus virtual port.
@@ -69,6 +80,9 @@ struct CommunicationConfig {
  * @brief This class contains low level gripper commands and status
  */
 class Communication {
+    static constexpr auto DEBUG_MODBUS = false;
+    static constexpr auto FAILURE_MODBUS = -1;
+
    public:
     Communication();
 
@@ -96,10 +110,8 @@ class Communication {
      *
      * @param none
      * @return int Connection status code.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    int configure();
+    void configure();
 
     /**
      * @brief Deinitializes communication layer.
@@ -116,7 +128,7 @@ class Communication {
      * @return connection status code.
      * @note The status should be checked to verify successful execution.
      */
-    int connect();
+    void connect();
 
     /**
      * @brief Disconnects from the gripper using Modbus RTU and a virtual socket.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -2,7 +2,6 @@
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
 #include <atomic>
-// #include <cstring>
 #include <optional>
 #include <string>
 #include <thread>

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -56,13 +56,13 @@ using InputBuffer = std::array<uint8_t, NUM_OF_INPUT_BYTES>;
  * @param th_sleep_rate The Modbus communication sleep rate.
  */
 struct CommunicationConfig {
-    const std::string tty_port;
-    const int baudrate;
-    const char parity;
-    const int data_bits;
-    const int stop_bit;
-    const int slave_id;
-    const std::chrono::milliseconds th_sleep_rate;
+    std::string tty_port;
+    int baudrate;
+    char parity;
+    int data_bits;
+    int stop_bit;
+    int slave_id;
+    std::chrono::milliseconds th_sleep_rate;
 };
 
 /**

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -2,9 +2,11 @@
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
 #include <atomic>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <modbus/modbus.h>
 
@@ -39,6 +41,44 @@ enum class InputBytes : uint8_t {
 };
 static constexpr auto NUM_OF_INPUT_BYTES = static_cast<size_t>(OutputBytes::BYTES_MAX);
 static constexpr auto INPUT_REGISTER_WORD_LENGTH = static_cast<uint>(InputBytes::BYTES_MAX) / 2;
+
+/**
+ * @brief An auxialry struct to hold and interpret the registers data.
+ */
+struct OutputRegisters {
+    // TODO add if for checking the reg range
+    uint8_t get(OutputBytes reg) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        return regs_[reg];
+    }
+
+    void set(OutputBytes reg, uint8_t val) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        regs_[reg] = val;
+    }
+
+    uint8_t regs_[NUM_OF_OUTPUT_BYTES];
+
+   private:
+    mutable std::mutex mtx_;
+};
+struct InputRegisters {
+    // TODO add if for checking the reg range
+    uint8_t get(InputBytes reg) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        return regs_[reg];
+    }
+
+    void set(InputBytes reg, uint8_t val) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        regs_[reg] = val;
+    }
+
+    uint8_t regs_[NUM_OF_INPUT_BYTES];
+
+   private:
+    mutable std::mutex mtx_;
+};
 
 /**
  * @brief This class contains low level gripper commands and status
@@ -115,48 +155,20 @@ class Communication {
     void disconnect();
 
     /**
-     * @brief Sets output bytes to zeros.
+     * @brief Retrieves all of the input bytes values.
      *
      * @param none
-     * @return None.
+     * @return Copy of the input bytes.
      */
-    void clear_output_bytes();
+    std::array<uint8_t, NUM_OF_INPUT_BYTES> get_input_bytes() const;
 
     /**
-     * @brief Retrieves the input byte value at the specified index.
+     * @brief Sets all of the output bytes values.
      *
-     * @param index The InputBytes byte index.
-     * @return Requested byte value.
-     */
-    uint8_t get_input_byte(InputBytes index);
-
-    /**
-     * @brief Sets the output byte value at the specified index.
-     *
-     * @param index OutputBytes byte index
-     * @param value The value to be set.
+     * @param vals The values to be set.
      * @return none
      */
-    void set_output_byte(OutputBytes index, uint8_t value);
-
-    /**
-     * @brief Sets the n-th bit of the action request byte.
-     *
-     * @param position_bit n-th bit in byte
-     * @param value The boolean value to set for the bit.
-     * @return None.
-     */
-    void write_action_bit(uint8_t position_bit, bool value);
-
-    /**
-     * @brief Sets the n-th bit of a number to the specified boolean value.
-     *
-     * @param number
-     * @param n The n-th bit position to set.
-     * @param x The boolean value to set the bit to.
-     * @return The modified number with the n-th bit set to the specified value.
-     */
-    uint bit_set_to(uint value, uint n, bool x);
+    void set_output_bytes(const std::array<uint8_t, NUM_OF_OUTPUT_BYTES>& vals);
 
    private:
     std::string tty_port_;
@@ -168,12 +180,10 @@ class Communication {
 
     modbus_t* mb_;
 
-    uint8_t input_bytes_modbus_[NUM_OF_INPUT_BYTES];
-    uint8_t output_bytes_modbus_[NUM_OF_OUTPUT_BYTES];
+    std::array<uint8_t, NUM_OF_INPUT_BYTES> input_bytes_;
+    std::array<uint8_t, NUM_OF_OUTPUT_BYTES> output_bytes_;
 
-    std::atomic<uint8_t> input_bytes_[NUM_OF_INPUT_BYTES];
-    std::atomic<uint8_t> output_bytes_[NUM_OF_OUTPUT_BYTES];
-
+    mutable std::mutex mtx_;
     std::atomic<bool> bg_comm_enabled_;
     std::optional<std::thread> bg_comm_;
 };

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -9,8 +9,8 @@
 
 namespace robotiq_hande_driver {
 
-static constexpr uint16_t GRIPPER_OUTPUT_FIRST_REG = 0x03E8;
-static constexpr uint16_t GRIPPER_INPUT_FIRST_REG = 0x07D0;
+static constexpr uint16_t SERIAL_OUTPUT_FIRST_REG = 0x03E8;
+static constexpr uint16_t SERIAL_INPUT_FIRST_REG = 0x07D0;
 
 enum class OutputBytes : uint8_t {
     RESERVED_1 = 0u,

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -1,12 +1,13 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
-#include <modbus/modbus.h>
 #include <atomic>
 #include <cstring>
 #include <optional>
 #include <string>
 #include <thread>
+
+#include <modbus/modbus.h>
 
 namespace robotiq_hande_driver {
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -2,20 +2,15 @@
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
 #include <array>
-#include <atomic>
-#include <chrono>
 #include <exception>
-#include <mutex>
-#include <optional>
 #include <string>
-#include <thread>
 
 #include <modbus/modbus.h>
 
 namespace robotiq_hande_driver {
 
-static constexpr uint16_t GRIPPER_OUTPUT_FIRST_REG = 0x07D0;
-static constexpr uint16_t GRIPPER_INPUT_FIRST_REG = 0x03E8;
+static constexpr uint16_t GRIPPER_OUTPUT_FIRST_REG = 0x03E8;
+static constexpr uint16_t GRIPPER_INPUT_FIRST_REG = 0x07D0;
 
 enum class OutputBytes : uint8_t {
     RESERVED_1 = 0u,
@@ -63,7 +58,6 @@ class CommunicationError : public std::exception {
  * @param data_bits Modbus serial data bits.
  * @param stop_bit Modbus serial stopbit.
  * @param slave_id Modbus slave id.
- * @param th_sleep_rate Sleep rate for modbus communication.
  */
 struct CommunicationConfig {
     std::string tty_port;
@@ -72,7 +66,6 @@ struct CommunicationConfig {
     int data_bits;
     int stop_bit;
     int slave_id;
-    std::chrono::milliseconds th_sleep_rate;
 };
 
 /**
@@ -95,11 +88,18 @@ class Communication {
     void initialize(const CommunicationConfig& cfg);
 
     /**
-     * @brief Reads and writes input/output registers at once.
+     * @brief Reads all of the input bytes values.
      *
-     * @note Used in external thread.
+     * @return Copy of the input bytes.
      */
-    void read_write_registers();
+    InputBuffer read() const;
+
+    /**
+     * @brief Writes all of the output bytes values.
+     *
+     * @param regs The values to be set.
+     */
+    void write(const OutputBuffer& regs) const;
 
     /**
      * @brief Initializes communication layer.
@@ -121,30 +121,9 @@ class Communication {
      */
     void disconnect();
 
-    /**
-     * @brief Retrieves all of the input bytes values.
-     *
-     * @return Copy of the input bytes.
-     */
-    InputBuffer get_input_bytes() const;
-
-    /**
-     * @brief Sets all of the output bytes values.
-     *
-     * @param vals The values to be set.
-     */
-    void set_output_bytes(const OutputBuffer& vals);
-
    private:
     CommunicationConfig cfg_;
     modbus_t* mb_;
-
-    InputBuffer input_bytes_;
-    OutputBuffer output_bytes_;
-
-    mutable std::mutex mtx_;
-    std::atomic<bool> th_comm_enabled_;
-    std::optional<std::thread> th_comm_;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -2,8 +2,11 @@
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
 #include <modbus/modbus.h>
+#include <atomic>
 #include <cstring>
+#include <optional>
 #include <string>
+#include <thread>
 
 namespace robotiq_hande_driver {
 
@@ -75,6 +78,56 @@ class Communication {
     };
 
     /**
+     * @brief Reads and writes input/output registers at once.
+     *
+     * @param none
+     * @return None.
+     * @note The status should be checked to verify successful execution. An exception is thrown if
+     * communication issues occur.
+     */
+    void read_write_registers() {
+        /**
+         * @brief Read and write modbus registers at once
+         *
+         * @param modbus_t *ctx
+         * @param int write_addr
+         * @param int write_nb
+         * @param uint16_t *src
+         * @param int read_addr
+         * @param int read_nb
+         * @param uint16_t *dest
+         * @return int FAILURE_MODBUS on failure, nonnegative value for success
+         * @note The status should be checked to verify successful execution. An exception is thrown
+         * if communication issues occur.
+         */
+        // int result;
+
+        while(running) {
+            // sleep for 100ms
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            for(size_t i = 0; i < static_cast<size_t>(OutputBytes::BYTES_MAX); ++i) {
+                output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
+            }
+
+            modbus_write_and_read_registers(
+                mb_,
+                GRIPPER_INPUT_FIRST_REG,
+                OUTPUT_REGISTER_WORD_LENGTH,
+                reinterpret_cast<uint16_t*>(output_bytes_modbus_),
+                GRIPPER_OUTPUT_FIRST_REG,
+                INPUT_REGISTER_WORD_LENGTH,
+                reinterpret_cast<uint16_t*>(input_bytes_modbus_));
+
+            for(size_t i = 0; i < static_cast<size_t>(InputBytes::BYTES_MAX); ++i) {
+                input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
+            }
+        }
+
+        // return result;
+    };
+
+    /**
      * @brief Initializes communication layer.
      *
      * @param none
@@ -90,6 +143,8 @@ class Communication {
         modbus_set_debug(mb_, DEBUG_MODBUS);
         result = connect();
 
+        my_thread.emplace(&Communication::read_write_registers, this);
+
         return result;
     };
 
@@ -102,6 +157,10 @@ class Communication {
      * communication issues occur.
      */
     void cleanup() {
+        if(my_thread && my_thread->joinable()) {
+            my_thread->join();
+        }
+
         disconnect();
         modbus_free(mb_);
     };
@@ -129,43 +188,6 @@ class Communication {
     };
 
     /**
-     * @brief Reads and writes input/output registers at once.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
-     */
-    int read_write_registers() {
-        /**
-         * @brief Read and write modbus registers at once
-         *
-         * @param modbus_t *ctx
-         * @param int write_addr
-         * @param int write_nb
-         * @param uint16_t *src
-         * @param int read_addr
-         * @param int read_nb
-         * @param uint16_t *dest
-         * @return int FAILURE_MODBUS on failure, nonnegative value for success
-         * @note The status should be checked to verify successful execution. An exception is thrown
-         * if communication issues occur.
-         */
-        int result;
-
-        result = modbus_write_and_read_registers(
-            mb_,
-            GRIPPER_INPUT_FIRST_REG,
-            OUTPUT_REGISTER_WORD_LENGTH,
-            reinterpret_cast<uint16_t*>(output_bytes_),
-            GRIPPER_OUTPUT_FIRST_REG,
-            INPUT_REGISTER_WORD_LENGTH,
-            reinterpret_cast<uint16_t*>(input_bytes_));
-
-        return result;
-    };
-
-    /**
      * @brief Sets output bytes to zeros.
      *
      * @param none
@@ -174,7 +196,10 @@ class Communication {
      * communication issues occur.
      */
     void clear_output_bytes() {
-        memset(output_bytes_, 0, sizeof(output_bytes_));
+        // memset(output_bytes_, 0, sizeof(output_bytes_));
+        for(size_t i = 0; i < static_cast<size_t>(OutputBytes::BYTES_MAX); ++i) {
+            output_bytes_[i].store(0, std::memory_order_relaxed);
+        }
     };
 
     /**
@@ -186,7 +211,7 @@ class Communication {
      * communication issues occur.
      */
     uint8_t get_input_byte(InputBytes index) {
-        return input_bytes_[static_cast<uint>(index)];
+        return input_bytes_[static_cast<uint>(index)].load(std::memory_order_relaxed);
     };
 
     /**
@@ -199,7 +224,7 @@ class Communication {
      * communication issues occur.
      */
     void set_output_byte(OutputBytes index, uint8_t value) {
-        output_bytes_[static_cast<uint>(index)] = value;
+        output_bytes_[static_cast<uint>(index)].store(value, std::memory_order_relaxed);
     };
 
     /**
@@ -210,8 +235,13 @@ class Communication {
      * @return None.
      */
     void write_action_bit(uint8_t position_bit, bool value) {
-        output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)] = bit_set_to(
-            output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)], position_bit, value);
+        output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)].store(
+            bit_set_to(
+                output_bytes_[static_cast<uint>(OutputBytes::ACTION_REQUEST)].load(
+                    std::memory_order_relaxed),
+                position_bit,
+                value),
+            std::memory_order_relaxed);
     };
 
     /**
@@ -238,8 +268,14 @@ class Communication {
 
     modbus_t* mb_;
 
-    uint8_t input_bytes_[static_cast<size_t>(InputBytes::BYTES_MAX)];
-    uint8_t output_bytes_[static_cast<size_t>(OutputBytes::BYTES_MAX)];
+    uint8_t input_bytes_modbus_[static_cast<size_t>(InputBytes::BYTES_MAX)];
+    uint8_t output_bytes_modbus_[static_cast<size_t>(OutputBytes::BYTES_MAX)];
+
+    std::atomic<uint8_t> input_bytes_[static_cast<size_t>(InputBytes::BYTES_MAX)];
+    std::atomic<uint8_t> output_bytes_[static_cast<size_t>(OutputBytes::BYTES_MAX)];
+
+    std::atomic<bool> running{true};
+    std::optional<std::thread> my_thread;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -2,7 +2,7 @@
 #define ROBOTIQ_HANDE_DRIVER__COMMUNICATION_HPP_
 
 #include <atomic>
-#include <cstring>
+// #include <cstring>
 #include <optional>
 #include <string>
 #include <thread>
@@ -160,7 +160,7 @@ class Communication {
     uint bit_set_to(uint value, uint n, bool x);
 
    private:
-    const char* tty_port_;
+    std::string tty_port_;
     int baudrate_;
     char parity_;
     int data_bits_;
@@ -175,7 +175,7 @@ class Communication {
     std::atomic<uint8_t> input_bytes_[NUM_OF_INPUT_BYTES];
     std::atomic<uint8_t> output_bytes_[NUM_OF_OUTPUT_BYTES];
 
-    std::atomic<bool> bg_comm_enabled_{true};
+    std::atomic<bool> bg_comm_enabled_;
     std::optional<std::thread> bg_comm_;
 };
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/communication.hpp
@@ -90,16 +90,16 @@ class Communication {
     /**
      * @brief Reads all of the input bytes values.
      *
-     * @return Copy of the input bytes.
+     * @param regs Place to read the input bytes.
      */
-    InputBuffer read() const;
+    void read(InputBuffer& regs) const;
 
     /**
      * @brief Writes all of the output bytes values.
      *
      * @param regs The values to be set.
      */
-    void write(const OutputBuffer& regs) const;
+    void write(OutputBuffer& regs) const;
 
     /**
      * @brief Initializes communication layer.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -41,23 +41,11 @@ class HandeGripper {
      *
      * @param gripper_position_min Minimal gripper position in meters.
      * @param gripper_position_max Maximal gripper position in meters.
-     * @param tty_port Modbus virtual port.
-     * @param baudrate Modbus serial baudrate.
-     * @param parity Modbus serial parity.
-     * @param data_bits Modbus serial data bits.
-     * @param stop_bit Modbus serial stopbit.
-     * @param slave_id Modbus slave id.
+     * @param cfg Modbus communication cfg.
      * @return None.
      */
     void initialize(
-        double gripper_position_min,
-        double gripper_position_max,
-        const std::string& tty_port,
-        int baudrate,
-        char parity,
-        int data_bits,
-        int stop_bit,
-        int slave_id);
+        double gripper_position_min, double gripper_position_max, const CommunicationConfig& cfg);
 
     /**
      * @brief Configures driver session.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -50,10 +50,8 @@ class HandeGripper {
     /**
      * @brief Configures driver session.
      * @return int Connection status code.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    int configure();
+    void configure();
 
     /**
      * @brief Deinitializes driver.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -150,22 +150,22 @@ class HandeGripper {
     void write();
 
    private:
-    // Handles protocol logic for mid-level abstraction.
-    ProtocolLogic protocol_logic_;
+    // Handles protocol logic for mid-level abstraction
+    ProtocolLogic prot_;
 
-    // Stores the gripper status bits.
+    // Stores the gripper status bits
     Status status_;
 
-    // Stores the fault status bits.
+    // Stores the fault status bits
     FaultStatus fault_status_;
 
-    // Stores the requested position of the gripper in meters.
+    // Stores the requested position of the gripper in meters
     double requested_position_;
 
-    // Stores the actual position of the gripper in meters.
+    // Stores the actual position of the gripper in meters
     double position_;
 
-    // Stores the electric current drawn by the gripper in amperes.
+    // Stores the electric current drawn by the gripper in amperes
     double current_;
 
     double gripper_position_min_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -2,7 +2,6 @@
 #define ROBOTIQ_HANDE_DRIVER__HANDE_GRIPPER_HPP_
 
 #include <stdint.h>
-#include <unistd.h>
 
 #include "robotiq_hande_driver/protocol_logic.hpp"
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -12,6 +12,7 @@ static constexpr auto GRIPPER_CURRENT_SCALE = 0.01;
 static constexpr auto MAX_SPEED = 255;
 static constexpr auto MAX_FORCE = 255;
 
+static constexpr auto EPSILON = 1e-6f;
 /**
  * @brief This class contains high-level gripper commands and status.
  */

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -1,5 +1,5 @@
-#ifndef ROBOTIQ_HANDE_DRIVER__APPLICATION_HPP_
-#define ROBOTIQ_HANDE_DRIVER__APPLICATION_HPP_
+#ifndef ROBOTIQ_HANDE_DRIVER__HANDE_GRIPPER_HPP_
+#define ROBOTIQ_HANDE_DRIVER__HANDE_GRIPPER_HPP_
 
 #include <stdint.h>
 #include <unistd.h>
@@ -15,7 +15,7 @@ static constexpr auto MAX_FORCE = 255;
 /**
  * @brief This class contains high-level gripper commands and status.
  */
-class GripperApplication {
+class HandeGripper {
    public:
     struct Status {
         bool is_reset;
@@ -31,9 +31,9 @@ class GripperApplication {
         bool is_error;
     };
 
-    GripperApplication();
+    HandeGripper();
 
-    ~GripperApplication() = default;
+    ~HandeGripper() = default;
 
     /**
      * @brief Initializes driver parameters.
@@ -261,4 +261,4 @@ class GripperApplication {
     double gripper_postion_step_;
 };
 }  // namespace robotiq_hande_driver
-#endif  // ROBOTIQ_HANDE_DRIVER__APPLICATION_HPP_
+#endif  // ROBOTIQ_HANDE_DRIVER__HANDE_GRIPPER_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_gripper.hpp
@@ -13,8 +13,9 @@ static constexpr auto MAX_SPEED = 255;
 static constexpr auto MAX_FORCE = 255;
 
 static constexpr auto EPSILON = 1e-6f;
+
 /**
- * @brief This class contains high-level gripper commands and status.
+ * @brief Contains high-level gripper commands and status.
  */
 class HandeGripper {
    public:
@@ -42,139 +43,85 @@ class HandeGripper {
      * @param gripper_position_min Minimal gripper position in meters.
      * @param gripper_position_max Maximal gripper position in meters.
      * @param cfg Modbus communication cfg.
-     * @return None.
      */
     void initialize(
         double gripper_position_min, double gripper_position_max, const CommunicationConfig& cfg);
 
     /**
      * @brief Configures driver session.
-     * @return int Connection status code.
      */
     void configure();
 
     /**
      * @brief Deinitializes driver.
-     *
-     * @param none
-     * @return None.
      */
     void cleanup();
 
     /**
      * @brief Stops the gripper movement.
-     *
-     * @param none
-     * @return None.
      */
     void stop();
 
     /**
      * @brief Resets the gripper by deactivating and reactivating it.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void reset();
 
     /**
      *  Emergency auto-release, gripper fingers are slowly opened, reactivation necessary
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void auto_release();
 
     /**
      * @brief Activates the gripper, making it ready for use.
-     *
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void activate();
 
     /**
      * @brief Deactivates the gripper.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void deactivate();
 
     /**
      * @brief Deactivates the gripper.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void shutdown();
 
     /**
      * @brief Opens the gripper.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void open();
 
     /**
      * @brief Closes the gripper.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void close();
 
     /**
      * @brief Retrieves the gripper status.
      *
-     * @param none
      * @return The current gripper status.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     Status get_status() const;
 
     /**
      * @brief Retrieves the gripper fault status.
      *
-     * @param none
      * @return The current gripper fault status.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     FaultStatus get_fault_status() const;
 
     /**
      * @brief Retrieves the requested position of the gripper.
      *
-     * @param none
      * @return The requested gripper position in meters.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     double get_requested_position() const;
 
     /**
      * @brief Retrieves the actual position of the gripper.
      *
-     * @param none
      * @return The actual gripper position in meters.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     double get_position() const;
 
@@ -182,65 +129,43 @@ class HandeGripper {
      * @brief Moves the gripper to the requested position.
      *
      * @param position The target position in meters.
-     * @return None.
      */
     void set_position(double position, double force = 1.0);
 
     /**
      * @brief Retrieves the electric current drawn by the gripper.
      *
-     * @param none
      * @return The electric current in amperes (range: 0–2.55 A)
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     double get_current() const;
 
     /**
      * @brief Reads gripper data.
-     *
-     * @param none
-     * @return None.
      */
     void read();
 
     /**
      * @brief Writes gripper data.
-     *
-     * @param none
-     * @return None.
      */
     void write();
 
    private:
-    /**
-     * Handles protocol logic for mid-level abstraction.
-     */
+    // Handles protocol logic for mid-level abstraction.
     ProtocolLogic protocol_logic_;
 
-    /**
-     * Stores the gripper status bits.
-     */
+    // Stores the gripper status bits.
     Status status_;
 
-    /**
-     * Stores the fault status bits.
-     */
+    // Stores the fault status bits.
     FaultStatus fault_status_;
 
-    /**
-     * Stores the requested position of the gripper in meters.
-     */
+    // Stores the requested position of the gripper in meters.
     double requested_position_;
 
-    /**
-     * Stores the actual position of the gripper in meters.
-     */
+    // Stores the actual position of the gripper in meters.
     double position_;
 
-    /**
-     * Stores the electric current drawn by the gripper in amperes.
-     */
+    // Stores the electric current drawn by the gripper in amperes.
     double current_;
 
     double gripper_position_min_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -37,7 +37,7 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
     rclcpp::Clock::SharedPtr get_clock() const;
 
    private:
-    void log_parsed_urdf_config() const;
+    void log_parsed_urdf_config();
 
     HandeGripper gripper_driver_;
     std::shared_ptr<rclcpp::Logger> logger_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -3,11 +3,11 @@
 
 #include <atomic>
 #include <chrono>
-#include <hardware_interface/system_interface.hpp>
 #include <optional>
-#include <rclcpp/rclcpp.hpp>
-#include <string>
 #include <thread>
+
+#include <hardware_interface/system_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include "robotiq_hande_driver/hande_gripper.hpp"
 #include "robotiq_hande_driver/socat_manager.hpp"

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -38,6 +38,7 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
 
    private:
     void log_parsed_urdf_config();
+    void initalize_gripper_driver();
 
     HandeGripper gripper_driver_;
     std::shared_ptr<rclcpp::Logger> logger_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -63,13 +63,15 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
 
     double state_position_;
     double state_velocity_;
-    std::atomic<double> read_position_;
-    std::atomic<double> read_velocity_;
+    std::mutex mtx_read_;
+    double read_position_;
+    double read_velocity_;
 
     double cmd_position_;
     double cmd_force_;
-    std::atomic<double> write_position_;
-    std::atomic<double> write_force_;
+    std::mutex mtx_write_;
+    double write_position_;
+    double write_force_;
 };
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -5,14 +5,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 
-#include "application.hpp"
+#include "robotiq_hande_driver/hande_gripper.hpp"
 
 namespace robotiq_hande_driver {
 
 namespace HWI = hardware_interface;
 namespace rlccp_lc = rclcpp_lifecycle;
 
-constexpr double EPSILON = 1e-6f;
 constexpr int LEFT_FINGER_JOINT_ID = 0;
 
 class RobotiqHandeHardwareInterface : public HWI::SystemInterface {

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -12,6 +12,7 @@ namespace robotiq_hande_driver {
 namespace HWI = hardware_interface;
 namespace rlccp_lc = rclcpp_lifecycle;
 
+constexpr double EPSILON = 1e-6f;
 constexpr int LEFT_FINGER_JOINT_ID = 0;
 
 class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
@@ -37,7 +38,7 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
     rclcpp::Clock::SharedPtr get_clock() const;
 
    private:
-    GripperApplication gripper_driver_;
+    HandeGripper gripper_driver_;
     std::shared_ptr<rclcpp::Logger> logger_;
     rclcpp::Clock::SharedPtr clock_;
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -1,9 +1,13 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__HANDE_HARDWARE_INTERFACE_HPP_
 #define ROBOTIQ_HANDE_DRIVER__HANDE_HARDWARE_INTERFACE_HPP_
 
+#include <atomic>
+#include <chrono>
 #include <hardware_interface/system_interface.hpp>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <thread>
 
 #include "robotiq_hande_driver/hande_gripper.hpp"
 
@@ -39,18 +43,28 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
    private:
     void log_parsed_urdf_config();
     void initalize_gripper_driver();
+    void gripper_communication();
 
     HandeGripper gripper_driver_;
     std::shared_ptr<rclcpp::Logger> logger_;
     rclcpp::Clock::SharedPtr clock_;
+
+    std::chrono::milliseconds th_sleep_rate_;
+    std::atomic<bool> th_comm_enabled_;
+    std::optional<std::thread> th_comm_;
 
     double gripper_position_min_;
     double gripper_position_max_;
 
     double state_position_;
     double state_velocity_;
+    std::atomic<double> read_position_;
+    std::atomic<double> read_velocity_;
+
     double cmd_position_;
     double cmd_force_;
+    std::atomic<double> write_position_;
+    std::atomic<double> write_force_;
 };
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -33,13 +33,8 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
     HWI::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
     HWI::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
-    rclcpp::Logger get_logger() const {
-        return *logger_;
-    }
-
-    rclcpp::Clock::SharedPtr get_clock() const {
-        return clock_;
-    }
+    rclcpp::Logger get_logger() const;
+    rclcpp::Clock::SharedPtr get_clock() const;
 
    private:
     GripperApplication gripper_driver_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -10,6 +10,7 @@
 #include <thread>
 
 #include "robotiq_hande_driver/hande_gripper.hpp"
+#include "robotiq_hande_driver/socat_manager.hpp"
 
 namespace robotiq_hande_driver {
 
@@ -21,6 +22,8 @@ constexpr int LEFT_FINGER_JOINT_ID = 0;
 class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
    public:
     RobotiqHandeHardwareInterface();
+
+    ~RobotiqHandeHardwareInterface();
 
     HWI::CallbackReturn on_init(const HWI::HardwareInfo& info) override;
     HWI::CallbackReturn on_configure(const rlccp_lc::State& previous_state) override;
@@ -46,6 +49,8 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
     void gripper_communication();
 
     HandeGripper gripper_driver_;
+    std::optional<SocatManager> socat_;
+
     std::shared_ptr<rclcpp::Logger> logger_;
     rclcpp::Clock::SharedPtr clock_;
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/hande_hardware_interface.hpp
@@ -37,18 +37,14 @@ class RobotiqHandeHardwareInterface : public HWI::SystemInterface {
     rclcpp::Clock::SharedPtr get_clock() const;
 
    private:
+    void log_parsed_urdf_config() const;
+
     HandeGripper gripper_driver_;
     std::shared_ptr<rclcpp::Logger> logger_;
     rclcpp::Clock::SharedPtr clock_;
 
     double gripper_position_min_;
     double gripper_position_max_;
-    std::string tty_port_;
-    int baudrate_;
-    char parity_;
-    int data_bits_;
-    int stop_bit_;
-    int slave_id_;
 
     double state_position_;
     double state_velocity_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -77,21 +77,10 @@ class ProtocolLogic {
     /**
      * @brief Initializes driver parameters.
      *
-     * @param tty_port Modbus virtual port.
-     * @param baudrate Modbus serial baudrate.
-     * @param parity Modbus serial parity.
-     * @param data_bits Modbus serial data bits.
-     * @param stop_bit Modbus serial stopbit.
-     * @param slave_id Modbus slave id.
+     * @param cfg Modbus communication config.
      * @return None.
      */
-    void initialize(
-        const std::string& tty_port,
-        int baudrate,
-        char parity,
-        int data_bits,
-        int stop_bit,
-        int slave_id);
+    void initialize(const CommunicationConfig& cfg);
 
     /**
      * @brief Configures protocol layer.
@@ -259,10 +248,10 @@ class ProtocolLogic {
     ObjectDetectionStatus object_detection_status_;
 
     /* Auxiary array for storing read value*/
-    std::array<uint8_t, NUM_OF_INPUT_BYTES> input_bytes_;
+    InputBuffer input_bytes_;
 
     /* Auxiary array for preparing all registers before sending them*/
-    std::array<uint8_t, NUM_OF_OUTPUT_BYTES> output_bytes_;
+    OutputBuffer output_bytes_;
 
     /* Fault */
     uint8_t fault_status_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -87,10 +87,8 @@ class ProtocolLogic {
      *
      * @param none
      * @return int Connection status code.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    int configure();
+    void configure();
 
     /**
      * @brief Deinitializes protocol layer.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -66,7 +66,7 @@ static constexpr auto GRIPPER_POSITION_OPENED_THRESHOLD = 230;
 static constexpr auto GRIPPER_POSITION_CLOSED_THRESHOLD = 13;
 
 /**
- * @brief This class contains protocol oriented functions and definitions.
+ * @brief Contains Robotiq's protocol oriented functions and definitions.
  */
 class ProtocolLogic {
    public:
@@ -78,65 +78,41 @@ class ProtocolLogic {
      * @brief Initializes driver parameters.
      *
      * @param cfg Modbus communication config.
-     * @return None.
      */
     void initialize(const CommunicationConfig& cfg);
 
     /**
      * @brief Configures protocol layer.
-     *
-     * @param none
-     * @return int Connection status code.
      */
     void configure();
 
     /**
      * @brief Deinitializes protocol layer.
-     *
-     * @param none
-     * @return None.
      */
     void cleanup();
 
     /**
      *  @brief Resets the gripper.
-     *
-     * @param none
-     * @return None.
      */
     void reset();
 
     /**
      *  @brief Sets the gripper.
-     *
-     * @param none
-     * @return None.
      */
     void set();
 
     /**
      * @brief Performs an emergency auto-release. The fingers slowly open, requiring reactivation.
-     *
-     * @param none
-     * @return None.
      */
     void auto_release();
 
     /**
      * @brief Activates the gripper, making it ready for use.
-     *
-     * @param none
-     * @return None.
      */
     void activate();
 
     /**
      * @brief Deactivates the gripper.
-     *
-     * @param none
-     * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void deactivate();
 
@@ -146,14 +122,11 @@ class ProtocolLogic {
      * @param position The requested position.
      * @param velocity The requested velocity.
      * @param force The requested force.
-     * @return None.
      */
     void go_to(uint8_t position, uint8_t velocity, uint8_t force);
 
     /**
      * @brief Stops the gripper.
-     *
-     * @return None.
      */
     void stop();
 
@@ -227,46 +200,47 @@ class ProtocolLogic {
      */
     uint8_t get_current() const;
 
-    // TODO docs
+    /**
+     * @brief Copies the the communication input registers into the working memory.
+     */
     void read_input_bytes();
+
+    /**
+     * @brief Copies the modified output bytes to the communication output registers.
+     */
     void write_output_bytes();
 
    private:
+    // Methods for accessing and manipulating auxiary arrays
     uint bit_set_to(uint value, uint n, bool x) const;
     void write_action_bit(uint8_t position_bit, bool value);
 
     uint8_t get_input_byte(InputBytes index) const;
     void set_output_byte(OutputBytes index, uint8_t value);
 
-    /* Gripper */
+    // Auxiary array for storing read values
+    InputBuffer input_bytes_;
+
+    // Auxiary array for preparing all registers before sending them
+    OutputBuffer output_bytes_;
+
+    // Gripper
     uint8_t status_;
     ActivationStatus activation_status_;
     ActionStatus action_status_;
     GripperStatus gripper_status_;
     ObjectDetectionStatus object_detection_status_;
 
-    /* Auxiary array for storing read value*/
-    InputBuffer input_bytes_;
-
-    /* Auxiary array for preparing all registers before sending them*/
-    OutputBuffer output_bytes_;
-
-    /* Fault */
+    // Fault
     uint8_t fault_status_;
 
-    /**
-     * @brief Stores the requested position in normalized 0–255 value.
-     */
+    // Stores the requested position in normalized 0–255 value.
     uint8_t position_request_echo_;
 
-    /**
-     * @brief Stores the actual position in normalized 0–255 value.
-     */
+    // Stores the actual position in normalized 0–255 value.
     uint8_t position_;
 
-    /**
-     * @brief Stores the electric current drawn by the gripper in 10 mA.
-     */
+    // Stores the electric current drawn by the gripper in 10 mA.
     uint8_t current_;
 
     Communication communication_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -182,23 +182,23 @@ class ProtocolLogic {
     /**
      * @brief Retrieves the requested position of the gripper.
      *
-     * @return Requested gripper position.
+     * @return Requested gripper position in raw value.
      */
-    uint8_t get_reg_pos() const;
+    uint8_t get_raw_requested_pos() const;
 
     /**
      * @brief Retrieves the actual position of the gripper.
      *
-     * @return The actual gripper position.
+     * @return The actual gripper position in raw value.
      */
-    uint8_t get_pos() const;
+    uint8_t get_raw_pos() const;
 
     /**
      * @brief Retrieves the electric current drawn by the gripper.
      *
-     * @return The electric current.
+     * @return The raw value of the electric current
      */
-    uint8_t get_current() const;
+    uint8_t get_raw_current() const;
 
     /**
      * @brief Copies the the communication input registers into the working memory.
@@ -218,6 +218,9 @@ class ProtocolLogic {
     uint8_t get_input_byte(InputBytes index) const;
     void set_output_byte(OutputBytes index, uint8_t value);
 
+    // Handles low-level communication in a separate thread
+    Communication communication_;
+
     // Auxiary array for storing read values
     InputBuffer input_bytes_;
 
@@ -225,25 +228,23 @@ class ProtocolLogic {
     OutputBuffer output_bytes_;
 
     // Gripper
-    uint8_t status_;
+    uint8_t raw_status_;
     ActivationStatus activation_status_;
     ActionStatus action_status_;
     GripperStatus gripper_status_;
     ObjectDetectionStatus object_detection_status_;
 
     // Fault
-    uint8_t fault_status_;
+    uint8_t raw_fault_status_;
 
-    // Stores the requested position in normalized 0–255 value.
-    uint8_t position_request_echo_;
+    // Stores the requested position in normalized 0–255 value
+    uint8_t raw_position_request_;
 
-    // Stores the actual position in normalized 0–255 value.
-    uint8_t position_;
+    // Stores the actual position in normalized 0–255 value
+    uint8_t raw_position_;
 
-    // Stores the electric current drawn by the gripper in 10 mA.
-    uint8_t current_;
-
-    Communication communication_;
+    // Stores the electric current drawn by the gripper in 10 mA value
+    uint8_t raw_current_;
 };
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__PROTOCOL_LOGIC_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -1,8 +1,6 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__PROTOCOL_LOGIC_HPP_
 #define ROBOTIQ_HANDE_DRIVER__PROTOCOL_LOGIC_HPP_
 
-#include <string>
-
 #include "robotiq_hande_driver/communication.hpp"
 
 namespace robotiq_hande_driver {

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -240,20 +240,29 @@ class ProtocolLogic {
      */
     uint8_t get_current() const;
 
-    /**
-     * @brief Decodes Modbus registers and refreshes appropriate data.
-     *
-     * @return None.
-     */
-    void refresh_registers();
+    // TODO docs
+    void read_input_bytes();
+    void write_output_bytes();
 
    private:
+    uint bit_set_to(uint value, uint n, bool x) const;
+    void write_action_bit(uint8_t position_bit, bool value);
+
+    uint8_t get_input_byte(InputBytes index) const;
+    void set_output_byte(OutputBytes index, uint8_t value);
+
     /* Gripper */
     uint8_t status_;
     ActivationStatus activation_status_;
     ActionStatus action_status_;
     GripperStatus gripper_status_;
     ObjectDetectionStatus object_detection_status_;
+
+    /* Auxiary array for storing read value*/
+    std::array<uint8_t, NUM_OF_INPUT_BYTES> input_bytes_;
+
+    /* Auxiary array for preparing all registers before sending them*/
+    std::array<uint8_t, NUM_OF_OUTPUT_BYTES> output_bytes_;
 
     /* Fault */
     uint8_t fault_status_;

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -146,7 +146,7 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
             static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
-        communication_.read_write_registers();
+        // communication_.read_write_registers();
     };
 
     /**
@@ -162,7 +162,7 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
             static_cast<bool>(Activate::ACTIVATE_GRIPPER));
-        communication_.read_write_registers();
+        // communication_.read_write_registers();
     };
 
     /**
@@ -180,7 +180,7 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE_DIRECTION),
             static_cast<bool>(AutoReleaseDirection::OPENING));
-        communication_.read_write_registers();
+        // communication_.read_write_registers();
     };
 
     /**
@@ -225,7 +225,7 @@ class ProtocolLogic {
         communication_.set_output_byte(OutputBytes::POSITION_REQUEST, position);
         communication_.set_output_byte(OutputBytes::SPEED, velocity);
         communication_.set_output_byte(OutputBytes::FORCE, force);
-        communication_.read_write_registers();
+        // communication_.read_write_registers();
     };
 
     /**
@@ -238,7 +238,7 @@ class ProtocolLogic {
     void stop() {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::STOP));
-        communication_.read_write_registers();
+        // communication_.read_write_registers();
     };
 
     /**

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -146,7 +146,6 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
             static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
-        // communication_.read_write_registers();
     };
 
     /**
@@ -162,7 +161,6 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
             static_cast<bool>(Activate::ACTIVATE_GRIPPER));
-        // communication_.read_write_registers();
     };
 
     /**
@@ -180,7 +178,6 @@ class ProtocolLogic {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE_DIRECTION),
             static_cast<bool>(AutoReleaseDirection::OPENING));
-        // communication_.read_write_registers();
     };
 
     /**
@@ -225,7 +222,6 @@ class ProtocolLogic {
         communication_.set_output_byte(OutputBytes::POSITION_REQUEST, position);
         communication_.set_output_byte(OutputBytes::SPEED, velocity);
         communication_.set_output_byte(OutputBytes::FORCE, force);
-        // communication_.read_write_registers();
     };
 
     /**
@@ -238,7 +234,6 @@ class ProtocolLogic {
     void stop() {
         communication_.write_action_bit(
             static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::STOP));
-        // communication_.read_write_registers();
     };
 
     /**

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -72,7 +72,7 @@ class ProtocolLogic {
    public:
     ProtocolLogic();
 
-    ~ProtocolLogic() {};
+    ~ProtocolLogic() = default;
 
     /**
      * @brief Initializes driver parameters.
@@ -84,8 +84,6 @@ class ProtocolLogic {
      * @param stop_bit Modbus serial stopbit.
      * @param slave_id Modbus slave id.
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
     void initialize(
         const std::string& tty_port,
@@ -93,9 +91,7 @@ class ProtocolLogic {
         char parity,
         int data_bits,
         int stop_bit,
-        int slave_id) {
-        communication_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
-    };
+        int slave_id);
 
     /**
      * @brief Configures protocol layer.
@@ -105,93 +101,47 @@ class ProtocolLogic {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    int configure() {
-        int result;
-
-        activation_status_ = ActivationStatus::GRIPPER_RESET;
-        action_status_ = ActionStatus::STOPPED;
-        gripper_status_ = GripperStatus::NOT_USED;
-        object_detection_status_ = ObjectDetectionStatus::REQ_POS_NO_OBJECT;
-        fault_status_ = 0;
-        position_request_echo_ = 0;
-        position_ = 0;
-        current_ = 0;
-        result = communication_.configure();
-
-        return result;
-    };
+    int configure();
 
     /**
      * @brief Deinitializes protocol layer.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void cleanup() {
-        communication_.cleanup();
-    };
+    void cleanup();
 
     /**
      *  @brief Resets the gripper.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void reset() {
-        communication_.clear_output_bytes();
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
-            static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
-    };
+    void reset();
 
     /**
      *  @brief Sets the gripper.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void set() {
-        communication_.clear_output_bytes();
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
-            static_cast<bool>(Activate::ACTIVATE_GRIPPER));
-    };
+    void set();
 
     /**
      * @brief Performs an emergency auto-release. The fingers slowly open, requiring reactivation.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void auto_release() {
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE),
-            static_cast<bool>(AutomaticRelease::EMERGENCY_AUTO_RELEASE));
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE_DIRECTION),
-            static_cast<bool>(AutoReleaseDirection::OPENING));
-    };
+    void auto_release();
 
     /**
      * @brief Activates the gripper, making it ready for use.
      *
      * @param none
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void activate() {
-        reset();
-        set();
-    };
+    void activate();
 
     /**
      * @brief Deactivates the gripper.
@@ -201,9 +151,7 @@ class ProtocolLogic {
      * @note The status should be checked to verify successful execution. An exception is thrown if
      * communication issues occur.
      */
-    void deactivate() {
-        reset();
-    };
+    void deactivate();
 
     /**
      * @brief Moves the gripper to the requested position with specified velocity and force.
@@ -212,127 +160,85 @@ class ProtocolLogic {
      * @param velocity The requested velocity.
      * @param force The requested force.
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void go_to(uint8_t position, uint8_t velocity, uint8_t force) {
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::GO_TO),
-            static_cast<bool>(GoTo::GO_TO_REQ_POS));
-        communication_.set_output_byte(OutputBytes::POSITION_REQUEST, position);
-        communication_.set_output_byte(OutputBytes::SPEED, velocity);
-        communication_.set_output_byte(OutputBytes::FORCE, force);
-    };
+    void go_to(uint8_t position, uint8_t velocity, uint8_t force);
 
     /**
      * @brief Stops the gripper.
      *
      * @return None.
-     * @note The status should be checked to verify successful execution. An exception is thrown if
-     * communication issues occur.
      */
-    void stop() {
-        communication_.write_action_bit(
-            static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::STOP));
-    };
+    void stop();
 
     /**
      * @brief Checks if the gripper is in reset state.
      *
      * @return True if the gripper is in reset state.
      */
-    bool is_reset() {
-        return (
-            gripper_status_ == GripperStatus::GRIPPER_IN_RESET
-            && activation_status_ == ActivationStatus::GRIPPER_RESET);
-    };
+    bool is_reset() const;
 
     /**
      * @brief Checks if the gripper is in ready state.
      *
      * @return True if the gripper is in ready state.
      */
-    bool is_ready() {
-        return (
-            gripper_status_ == GripperStatus::ACTIVATION_COMPLETE
-            && activation_status_ == ActivationStatus::GRIPPER_ACTIVATION);
-    };
+    bool is_ready() const;
 
     /**
      * @brief Checks if the gripper is moving.
      *
      * @return True if gripper is moving.
      */
-    bool is_moving() {
-        return (
-            action_status_ == ActionStatus::GO_TO_POSITION_REQUEST
-            && object_detection_status_ == ObjectDetectionStatus::MOTION_NO_OBJECT);
-    };
+    bool is_moving() const;
 
     /**
      * @brief Checks if the gripper is stopped.
      *
      * @return True if gripper is stopped.
      */
-    bool is_stopped() {
-        return object_detection_status_ != ObjectDetectionStatus::MOTION_NO_OBJECT;
-    };
+    bool is_stopped() const;
 
     /**
      * @brief Checks if the gripper is closed.
      *
      * @return True if gripper is closed.
      */
-    bool is_closed() {
-        return position_ >= GRIPPER_POSITION_OPENED_THRESHOLD;
-    };
+    bool is_closed() const;
 
     /**
      * @brief Checks if the gripper is opened.
      *
      * @return True if gripper is opened.
      */
-    bool is_opened() {
-        return position_ <= GRIPPER_POSITION_CLOSED_THRESHOLD;
-    };
+    bool is_opened() const;
 
     /**
      * @brief Checks if the gripper has detected an object.
      *
      * @return True if gripper has detected an object.
      */
-    bool obj_detected() {
-        return (
-            object_detection_status_ == ObjectDetectionStatus::STOPPED_OPENING_DETECTED
-            || object_detection_status_ == ObjectDetectionStatus::STOPPED_CLOSING_DETECTED);
-    };
+    bool obj_detected() const;
 
     /**
      * @brief Retrieves the requested position of the gripper.
      *
      * @return Requested gripper position.
      */
-    uint8_t get_reg_pos() {
-        return position_request_echo_;
-    };
+    uint8_t get_reg_pos() const;
 
     /**
      * @brief Retrieves the actual position of the gripper.
      *
      * @return The actual gripper position.
      */
-    uint8_t get_pos() {
-        return position_;
-    };
+    uint8_t get_pos() const;
 
     /**
      * @brief Retrieves the electric current drawn by the gripper.
      *
      * @return The electric current.
      */
-    uint8_t get_current() {
-        return current_;
-    };
+    uint8_t get_current() const;
 
     /**
      * @brief Decodes Modbus registers and refreshes appropriate data.

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/protocol_logic.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "communication.hpp"
+#include "robotiq_hande_driver/communication.hpp"
 
 namespace robotiq_hande_driver {
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
@@ -13,7 +13,7 @@
 
 namespace robotiq_hande_driver {
 
-static constexpr auto WAIT_FOR_SOCAT = std::chrono::milliseconds(1000);
+static constexpr auto WAIT_FOR_SOCAT_CONNECTION = std::chrono::milliseconds(1000);
 
 class SocatManager {
    public:

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
@@ -1,0 +1,40 @@
+#ifndef ROBOTIQ_HANDE_DRIVER__SOCAT_MANAGER_HPP_
+#define ROBOTIQ_HANDE_DRIVER__SOCAT_MANAGER_HPP_
+
+#include <chrono>
+#include <cstdlib>
+#include <exception>
+#include <string>
+#include <thread>
+
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace robotiq_hande_driver {
+
+static constexpr auto WAIT_FOR_SOCAT = std::chrono::milliseconds(100);
+
+class SocatManager {
+   public:
+    SocatManager(const std::string& host, int port, const std::string& tty_path);
+
+    ~SocatManager();
+
+    void start();
+
+    void stop();
+
+    bool is_alive() const;
+
+   private:
+    pid_t socat_pid_;
+    bool started_;
+
+    std::string host_;
+    int port_;
+    std::string tty_path_;
+};
+
+}  // namespace robotiq_hande_driver
+#endif  // ROBOTIQ_HANDE_DRIVER__SOCAT_MANAGER_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
@@ -13,7 +13,7 @@
 
 namespace robotiq_hande_driver {
 
-static constexpr auto WAIT_FOR_SOCAT = std::chrono::milliseconds(100);
+static constexpr auto WAIT_FOR_SOCAT = std::chrono::milliseconds(1000);
 
 class SocatManager {
    public:

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/socat_manager.hpp
@@ -2,10 +2,7 @@
 #define ROBOTIQ_HANDE_DRIVER__SOCAT_MANAGER_HPP_
 
 #include <chrono>
-#include <cstdlib>
-#include <exception>
 #include <string>
-#include <thread>
 
 #include <signal.h>
 #include <sys/wait.h>

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
@@ -13,11 +13,13 @@ constexpr const char* RESET = "\033[0m";
 constexpr const char* RED = "\033[31m";
 constexpr const char* GREEN = "\033[32m";
 constexpr const char* YELLOW = "\033[33m";
+constexpr const char* CYAN = "\033[36m";
 
 // Bold/bright variants
 constexpr const char* BRED = "\033[1;31m";
 constexpr const char* BGREEN = "\033[1;32m";
 constexpr const char* BYELLOW = "\033[1;33m";
+constexpr const char* BCYAN = "\033[1;36m";
 
 }  // namespace color
 

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
@@ -1,6 +1,10 @@
 #ifndef ROBOTIQ_HANDE_DRIVER__UTILS_HPP_
 #define ROBOTIQ_HANDE_DRIVER__UTILS_HPP_
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
 namespace robotiq_hande_driver {
 
 // Symbols for formatting the CLI output.
@@ -22,6 +26,12 @@ constexpr const char* BYELLOW = "\033[1;33m";
 constexpr const char* BCYAN = "\033[1;36m";
 
 }  // namespace color
+
+std::string str_to_lower(const std::string& str) {
+    std::string s(str);
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    return s;
+}
 
 }  // namespace robotiq_hande_driver
 #endif  // ROBOTIQ_HANDE_DRIVER__UTILS_HPP_

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
@@ -3,39 +3,22 @@
 
 namespace robotiq_hande_driver {
 
+// Symbols for formatting the CLI output.
 namespace color {
+
 // Reset
 constexpr const char* RESET = "\033[0m";
 
 // Regular colors
-constexpr const char* BLACK = "\033[30m";
 constexpr const char* RED = "\033[31m";
 constexpr const char* GREEN = "\033[32m";
 constexpr const char* YELLOW = "\033[33m";
-constexpr const char* BLUE = "\033[34m";
-constexpr const char* MAGENTA = "\033[35m";
-constexpr const char* CYAN = "\033[36m";
-constexpr const char* WHITE = "\033[37m";
 
 // Bold/bright variants
-constexpr const char* BBLACK = "\033[1;30m";
 constexpr const char* BRED = "\033[1;31m";
 constexpr const char* BGREEN = "\033[1;32m";
 constexpr const char* BYELLOW = "\033[1;33m";
-constexpr const char* BBLUE = "\033[1;34m";
-constexpr const char* BMAGENTA = "\033[1;35m";
-constexpr const char* BCYAN = "\033[1;36m";
-constexpr const char* BWHITE = "\033[1;37m";
 
-// Background colors (optional)
-constexpr const char* BG_BLACK = "\033[40m";
-constexpr const char* BG_RED = "\033[41m";
-constexpr const char* BG_GREEN = "\033[42m";
-constexpr const char* BG_YELLOW = "\033[43m";
-constexpr const char* BG_BLUE = "\033[44m";
-constexpr const char* BG_MAGENTA = "\033[45m";
-constexpr const char* BG_CYAN = "\033[46m";
-constexpr const char* BG_WHITE = "\033[47m";
 }  // namespace color
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
+++ b/robotiq_hande_driver/hardware/include/robotiq_hande_driver/utils.hpp
@@ -1,0 +1,42 @@
+#ifndef ROBOTIQ_HANDE_DRIVER__UTILS_HPP_
+#define ROBOTIQ_HANDE_DRIVER__UTILS_HPP_
+
+namespace robotiq_hande_driver {
+
+namespace color {
+// Reset
+constexpr const char* RESET = "\033[0m";
+
+// Regular colors
+constexpr const char* BLACK = "\033[30m";
+constexpr const char* RED = "\033[31m";
+constexpr const char* GREEN = "\033[32m";
+constexpr const char* YELLOW = "\033[33m";
+constexpr const char* BLUE = "\033[34m";
+constexpr const char* MAGENTA = "\033[35m";
+constexpr const char* CYAN = "\033[36m";
+constexpr const char* WHITE = "\033[37m";
+
+// Bold/bright variants
+constexpr const char* BBLACK = "\033[1;30m";
+constexpr const char* BRED = "\033[1;31m";
+constexpr const char* BGREEN = "\033[1;32m";
+constexpr const char* BYELLOW = "\033[1;33m";
+constexpr const char* BBLUE = "\033[1;34m";
+constexpr const char* BMAGENTA = "\033[1;35m";
+constexpr const char* BCYAN = "\033[1;36m";
+constexpr const char* BWHITE = "\033[1;37m";
+
+// Background colors (optional)
+constexpr const char* BG_BLACK = "\033[40m";
+constexpr const char* BG_RED = "\033[41m";
+constexpr const char* BG_GREEN = "\033[42m";
+constexpr const char* BG_YELLOW = "\033[43m";
+constexpr const char* BG_BLUE = "\033[44m";
+constexpr const char* BG_MAGENTA = "\033[45m";
+constexpr const char* BG_CYAN = "\033[46m";
+constexpr const char* BG_WHITE = "\033[47m";
+}  // namespace color
+
+}  // namespace robotiq_hande_driver
+#endif  // ROBOTIQ_HANDE_DRIVER__UTILS_HPP_

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -13,6 +13,19 @@ GripperApplication::GripperApplication()
       gripper_postion_step_() {}
 
 void GripperApplication::read() {
+    // static int divider = 0;
+
+    // if(protocol_logic_.is_ready()){
+    //     divider++;
+    //     if(divider==1000){
+    //         divider=0;
+    //         protocol_logic_.refresh_registers();
+    //     }
+    // }
+    // else{
+    //    protocol_logic_.refresh_registers();
+    // }
+
     protocol_logic_.refresh_registers();
 
     status_.is_reset = protocol_logic_.is_reset();

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -13,19 +13,6 @@ GripperApplication::GripperApplication()
       gripper_postion_step_() {}
 
 void GripperApplication::read() {
-    // static int divider = 0;
-
-    // if(protocol_logic_.is_ready()){
-    //     divider++;
-    //     if(divider==1000){
-    //         divider=0;
-    //         protocol_logic_.refresh_registers();
-    //     }
-    // }
-    // else{
-    //    protocol_logic_.refresh_registers();
-    // }
-
     protocol_logic_.refresh_registers();
 
     status_.is_reset = protocol_logic_.is_reset();

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -71,11 +71,11 @@ void GripperApplication::close() {
     set_position(gripper_position_min_);
 }
 
-const GripperApplication::Status& GripperApplication::get_status() const {
+GripperApplication::Status GripperApplication::get_status() const {
     return status_;
 }
 
-const GripperApplication::FaultStatus& GripperApplication::get_fault_status() const {
+GripperApplication::FaultStatus GripperApplication::get_fault_status() const {
     return fault_status_;
 }
 

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -71,11 +71,11 @@ void GripperApplication::close() {
     set_position(gripper_position_min_);
 }
 
-const Status& GripperApplication::get_status() const {
+const GripperApplication::Status& GripperApplication::get_status() const {
     return status_;
 }
 
-const FaultStatus& GripperApplication::get_fault_status() const {
+const GripperApplication::FaultStatus& GripperApplication::get_fault_status() const {
     return fault_status_;
 }
 
@@ -87,7 +87,7 @@ double GripperApplication::get_position() const {
     return position_;
 }
 
-void GripperApplication::set_position(double position, double force = 1.0) {
+void GripperApplication::set_position(double position, double force) {
     uint8_t scaled_force = static_cast<uint8_t>(force * MAX_FORCE);
     protocol_logic_.go_to(
         (uint8_t)((gripper_position_max_ - position) / gripper_postion_step_),

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -5,12 +5,99 @@
 namespace robotiq_hande_driver {
 
 GripperApplication::GripperApplication()
-    : requested_position_(),
-      position_(),
-      current_(),
-      gripper_position_min_(),
-      gripper_position_max_(),
-      gripper_postion_step_() {}
+    : protocol_logic_{},
+      status_{},
+      fault_status_{},
+      requested_position_{},
+      position_{},
+      current_{},
+      gripper_position_min_{},
+      gripper_position_max_{},
+      gripper_postion_step_{} {}
+
+void GripperApplication::initialize(
+    double gripper_position_min,
+    double gripper_position_max,
+    const std::string& tty_port,
+    int baudrate,
+    char parity,
+    int data_bits,
+    int stop_bit,
+    int slave_id) {
+    gripper_position_min_ = gripper_position_min;
+    gripper_position_max_ = gripper_position_max;
+    gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;
+    protocol_logic_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
+}
+
+int GripperApplication::configure() {
+    return protocol_logic_.configure();
+}
+
+void GripperApplication::cleanup() {
+    protocol_logic_.cleanup();
+}
+
+void GripperApplication::stop() {
+    protocol_logic_.stop();
+}
+
+void GripperApplication::reset() {
+    protocol_logic_.reset();
+}
+
+void GripperApplication::auto_release() {
+    protocol_logic_.auto_release();
+}
+
+void GripperApplication::activate() {
+    protocol_logic_.activate();
+}
+
+void GripperApplication::deactivate() {
+    protocol_logic_.reset();
+}
+
+void GripperApplication::shutdown() {
+    deactivate();
+    cleanup();
+}
+
+void GripperApplication::open() {
+    set_position(gripper_position_max_);
+}
+
+void GripperApplication::close() {
+    set_position(gripper_position_min_);
+}
+
+const Status& GripperApplication::get_status() const {
+    return status_;
+}
+
+const FaultStatus& GripperApplication::get_fault_status() const {
+    return fault_status_;
+}
+
+double GripperApplication::get_requested_position() const {
+    return requested_position_;
+}
+
+double GripperApplication::get_position() const {
+    return position_;
+}
+
+void GripperApplication::set_position(double position, double force = 1.0) {
+    uint8_t scaled_force = static_cast<uint8_t>(force * MAX_FORCE);
+    protocol_logic_.go_to(
+        (uint8_t)((gripper_position_max_ - position) / gripper_postion_step_),
+        MAX_SPEED,
+        scaled_force);
+}
+
+double GripperApplication::get_current() const {
+    return current_;
+}
 
 void GripperApplication::read() {
     protocol_logic_.refresh_registers();
@@ -24,10 +111,14 @@ void GripperApplication::read() {
     status_.object_detected = protocol_logic_.obj_detected();
 
     // fault_status
-
     requested_position_ = gripper_position_max_
                           - (double)protocol_logic_.get_reg_pos() * gripper_postion_step_;
     position_ = gripper_position_max_ - (double)protocol_logic_.get_pos() * gripper_postion_step_;
     current_ = (double)protocol_logic_.get_current() * GRIPPER_CURRENT_SCALE;
 }
+
+void GripperApplication::write() {
+    protocol_logic_.refresh_registers();
+}
+
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/application.cpp
+++ b/robotiq_hande_driver/hardware/src/application.cpp
@@ -118,7 +118,11 @@ void GripperApplication::read() {
 }
 
 void GripperApplication::write() {
+    // TODO investigate: we shouldn't read statue during the write phase
     protocol_logic_.refresh_registers();
+
+    // Here we should take internal registers and send them to the gripper
+    //  I.e. call set_position()
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -15,7 +15,7 @@ void Communication::initialize(const CommunicationConfig& cfg) {
 void Communication::read(InputBuffer& regs) const {
     auto result = modbus_read_registers(
         mb_,
-        GRIPPER_INPUT_FIRST_REG,
+        SERIAL_INPUT_FIRST_REG,
         INPUT_REGISTER_WORD_LENGTH,
         reinterpret_cast<uint16_t*>(regs.data()));
 
@@ -28,7 +28,7 @@ void Communication::read(InputBuffer& regs) const {
 void Communication::write(OutputBuffer& regs) const {
     auto result = modbus_write_registers(
         mb_,
-        GRIPPER_OUTPUT_FIRST_REG,
+        SERIAL_OUTPUT_FIRST_REG,
         OUTPUT_REGISTER_WORD_LENGTH,
         reinterpret_cast<uint16_t*>(regs.data()));
 

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -4,15 +4,16 @@
 
 namespace robotiq_hande_driver {
 
-Communication::Communication() : input_bytes_{}, output_bytes_{} {}
+Communication::Communication()
+    : input_bytes_modbus_{}, output_bytes_modbus_{}, input_bytes_{}, output_bytes_{} {}
 
 int Communication::connect() {
-    int result;
+    // int result;
 
     modbus_connect(mb_);
 
-    result = read_write_registers();
+    // read_write_registers();
 
-    return result;
+    return 0;
 }
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -13,8 +13,6 @@ Communication::Communication()
       stop_bit_{},
       slave_id_{},
       mb_{nullptr},
-      input_bytes_modbus_{},
-      output_bytes_modbus_{},
       input_bytes_{},  // TODO setup proper initial values
       output_bytes_{},
       bg_comm_enabled_{false} {}

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -68,7 +68,8 @@ int Communication::configure() {
     mb_ = modbus_new_rtu(tty_port_.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
     modbus_set_slave(mb_, slave_id_);
     modbus_set_debug(mb_, DEBUG_MODBUS);
-    // TODO: asynchronusly connect to the modbus TCP (wait for a virtual serial port creation from socat)
+    // TODO: asynchronously connect to the modbus TCP (wait for a virtual serial port creation from
+    // socat)
     auto result = connect();
 
     bg_comm_enabled_.store(true, std::memory_order_relaxed);

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -48,8 +48,7 @@ int Communication::configure() {
         modbus_set_slave(mb_, cfg_.slave_id);
         modbus_set_debug(mb_, DEBUG_MODBUS);
     }
-    // TODO: asynchronously connect to the modbus TCP (wait for a virtual serial port creation from
-    // socat)
+
     auto result = connect();
     if(result == FAILURE_MODBUS) {
         std::cout << "[WARNING] [robotiq_hande_driver] Failed to establish Modbus connection.\n";
@@ -61,8 +60,6 @@ int Communication::configure() {
         th_comm_.emplace(&Communication::read_write_registers, this);
     }
 
-    // TODO do we really need the result?
-    // Can we switch to more roboust throw & catch?
     return result;
 }
 

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -15,7 +15,7 @@ Communication::Communication()
       mb_{nullptr},
       input_bytes_modbus_{},
       output_bytes_modbus_{},
-      input_bytes_{},
+      input_bytes_{},  // TODO setup proper initial values
       output_bytes_{},
       bg_comm_enabled_{false} {}
 
@@ -41,43 +41,46 @@ void Communication::initialize(
 void Communication::read_write_registers() {
     int result = 0;
     while(bg_comm_enabled_) {
-        // TODO parametrize the sleep time
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-        for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
-            output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
+        {
+            std::lock_guard<std::mutex> lock(mtx_);
+            result = modbus_write_and_read_registers(
+                mb_,
+                GRIPPER_INPUT_FIRST_REG,
+                OUTPUT_REGISTER_WORD_LENGTH,
+                reinterpret_cast<uint16_t*>(output_bytes_.data()),
+                GRIPPER_OUTPUT_FIRST_REG,
+                INPUT_REGISTER_WORD_LENGTH,
+                reinterpret_cast<uint16_t*>(input_bytes_.data()));
         }
-
-        result = modbus_write_and_read_registers(
-            mb_,
-            GRIPPER_INPUT_FIRST_REG,
-            OUTPUT_REGISTER_WORD_LENGTH,
-            reinterpret_cast<uint16_t*>(output_bytes_modbus_),
-            GRIPPER_OUTPUT_FIRST_REG,
-            INPUT_REGISTER_WORD_LENGTH,
-            reinterpret_cast<uint16_t*>(input_bytes_modbus_));
         if(result == FAILURE_MODBUS)
             std::cout << "[WARNING] Failed to read & write Hand-e registers via modbus\n";
 
-        for(size_t i = 0; i < NUM_OF_INPUT_BYTES; ++i) {
-            input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
-        }
+        // TODO parametrize the sleep time
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 }
 
 int Communication::configure() {
-    mb_ = modbus_new_rtu(tty_port_.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
-    modbus_set_slave(mb_, slave_id_);
-    modbus_set_debug(mb_, DEBUG_MODBUS);
+    if(mb_ == nullptr) {
+        mb_ = modbus_new_rtu(tty_port_.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
+        modbus_set_slave(mb_, slave_id_);
+        modbus_set_debug(mb_, DEBUG_MODBUS);
+    }
     // TODO: asynchronously connect to the modbus TCP (wait for a virtual serial port creation from
     // socat)
     auto result = connect();
+    if(result == FAILURE_MODBUS) {
+        std::cout << "[WARNING] [robotiq_hande_driver] Failed to establish Modbus connection.\n";
+        return FAILURE_MODBUS;
+    }
 
     if(!bg_comm_enabled_) {
         bg_comm_enabled_.store(true, std::memory_order_relaxed);
         bg_comm_.emplace(&Communication::read_write_registers, this);
     }
 
+    // TODO do we really need the result?
+    // Can we switch to more roboust throw & catch?
     return result;
 }
 
@@ -95,8 +98,6 @@ void Communication::cleanup() {
 
 int Communication::connect() {
     auto result = modbus_connect(mb_);
-    if(result == FAILURE_MODBUS)
-        std::cout << "[WARNING] [robotiq_hande_driver] Failed to establish Modbus connection.\n";
     return result;
 }
 
@@ -104,34 +105,14 @@ void Communication::disconnect() {
     modbus_close(mb_);
 }
 
-void Communication::clear_output_bytes() {
-    for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
-        output_bytes_[i].store(0, std::memory_order_relaxed);
-    }
-    std::memset(output_bytes_modbus_, 0, sizeof(output_bytes_modbus_));
+std::array<uint8_t, NUM_OF_INPUT_BYTES> Communication::get_input_bytes() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return input_bytes_;
 }
 
-uint8_t Communication::get_input_byte(InputBytes index) {
-    auto idx = static_cast<uint>(index);
-    return input_bytes_[idx].load(std::memory_order_relaxed);
+void Communication::set_output_bytes(const std::array<uint8_t, NUM_OF_OUTPUT_BYTES>& vals) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    output_bytes_ = vals;
 }
 
-void Communication::set_output_byte(OutputBytes index, uint8_t value) {
-    auto idx = static_cast<uint>(index);
-    output_bytes_[idx].store(value, std::memory_order_relaxed);
-}
-
-void Communication::write_action_bit(uint8_t position_bit, bool value) {
-    auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST);
-    auto reg = output_bytes_[idx].load(std::memory_order_relaxed);
-    auto result = bit_set_to(reg, position_bit, value);
-
-    output_bytes_[idx].store(result, std::memory_order_relaxed);
-}
-
-uint Communication::bit_set_to(uint value, uint n, bool x) {
-    uint reset_n_bit = ~(1u << n);
-    uint set_n_bit = static_cast<uint>(x) << n;
-    return (value & reset_n_bit) | set_n_bit;
-}
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -36,9 +36,9 @@ void Communication::write(OutputBuffer& regs) const {
         reinterpret_cast<uint16_t*>(regs.data()));
 
     if(result == FAILURE_MODBUS)
-        throw CommunicationError("Failed to read registers (Modbus failure)");
+        throw CommunicationError("Failed to write registers (Modbus failure)");
     if(result != OUTPUT_REGISTER_WORD_LENGTH)
-        throw CommunicationError("Failed to read all requested registers");
+        throw CommunicationError("Failed to write all requested registers");
 }
 
 void Communication::configure() {

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -1,11 +1,24 @@
 #include "robotiq_hande_driver/communication.hpp"
 
-#include <cstdio>
+// #include <cstdio>
+#include <iostream>
+#include <stdexcept>
 
 namespace robotiq_hande_driver {
 
 Communication::Communication()
-    : input_bytes_modbus_{}, output_bytes_modbus_{}, input_bytes_{}, output_bytes_{} {}
+    : tty_port_{},
+      baudrate_{},
+      parity_{},
+      data_bits_{},
+      stop_bit_{},
+      slave_id_{},
+      mb_{nullptr},
+      input_bytes_modbus_{},
+      output_bytes_modbus_{},
+      input_bytes_{},
+      output_bytes_{},
+      bg_comm_enabled_{true} {}
 
 Communication::~Communication() {
     cleanup();
@@ -18,7 +31,7 @@ void Communication::initialize(
     int data_bits,
     int stop_bit,
     int slave_id) {
-    tty_port_ = tty_port.c_str();
+    tty_port_ = tty_port;
     baudrate_ = baudrate;
     parity_ = parity;
     data_bits_ = data_bits;
@@ -27,6 +40,7 @@ void Communication::initialize(
 }
 
 void Communication::read_write_registers() {
+    int result = 0;
     while(bg_comm_enabled_) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
@@ -34,7 +48,7 @@ void Communication::read_write_registers() {
             output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
         }
 
-        modbus_write_and_read_registers(
+        result = modbus_write_and_read_registers(
             mb_,
             GRIPPER_INPUT_FIRST_REG,
             OUTPUT_REGISTER_WORD_LENGTH,
@@ -42,6 +56,8 @@ void Communication::read_write_registers() {
             GRIPPER_OUTPUT_FIRST_REG,
             INPUT_REGISTER_WORD_LENGTH,
             reinterpret_cast<uint16_t*>(input_bytes_modbus_));
+        if(result == FAILURE_MODBUS)
+            std::cout << "[WARNING] Failed to read & write Hand-e registers via modbus\n";
 
         for(size_t i = 0; i < NUM_OF_INPUT_BYTES; ++i) {
             input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
@@ -50,11 +66,12 @@ void Communication::read_write_registers() {
 }
 
 int Communication::configure() {
-    mb_ = modbus_new_rtu(tty_port_, baudrate_, parity_, data_bits_, stop_bit_);
+    mb_ = modbus_new_rtu(tty_port.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
     modbus_set_slave(mb_, slave_id_);
     modbus_set_debug(mb_, DEBUG_MODBUS);
     auto result = connect();
 
+    bg_comm_enabled_.store(true, std::memory_order_relaxed);
     bg_comm_.emplace(&Communication::read_write_registers, this);
 
     return result;
@@ -66,12 +83,17 @@ void Communication::cleanup() {
         bg_comm_->join();
     }
 
+    if(mb_ == nullptr) return;
     disconnect();
     modbus_free(mb_);
+    mb_ = nullptr;
 }
 
 int Communication::connect() {
-    return modbus_connect(mb_);
+    auto result = modbus_connect(mb_);
+    if(result == FAILURE_MODBUS)
+        throw std::runtime_error("[robotiq_hande_driver] Failed to establish Modbus connection.");
+    return result;
 }
 
 void Communication::disconnect() {
@@ -96,7 +118,7 @@ void Communication::set_output_byte(OutputBytes index, uint8_t value) {
 }
 
 void Communication::write_action_bit(uint8_t position_bit, bool value) {
-    auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST;
+    auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST);
     auto reg = output_bytes_[idx].load(std::memory_order_relaxed);
     auto result = bit_set_to(reg, position_bit, value);
 

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -1,8 +1,7 @@
 #include "robotiq_hande_driver/communication.hpp"
 
-// #include <cstdio>
+#include <cstring>
 #include <iostream>
-#include <stdexcept>
 
 namespace robotiq_hande_driver {
 
@@ -66,9 +65,10 @@ void Communication::read_write_registers() {
 }
 
 int Communication::configure() {
-    mb_ = modbus_new_rtu(tty_port.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
+    mb_ = modbus_new_rtu(tty_port_.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
     modbus_set_slave(mb_, slave_id_);
     modbus_set_debug(mb_, DEBUG_MODBUS);
+    // TODO: asynchronusly connect to the modbus TCP (wait for a virtual serial port creation from socat)
     auto result = connect();
 
     bg_comm_enabled_.store(true, std::memory_order_relaxed);
@@ -92,7 +92,7 @@ void Communication::cleanup() {
 int Communication::connect() {
     auto result = modbus_connect(mb_);
     if(result == FAILURE_MODBUS)
-        throw std::runtime_error("[robotiq_hande_driver] Failed to establish Modbus connection.");
+        std::cout << "[WARNING] [robotiq_hande_driver] Failed to establish Modbus connection.\n";
     return result;
 }
 
@@ -104,7 +104,7 @@ void Communication::clear_output_bytes() {
     for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
         output_bytes_[i].store(0, std::memory_order_relaxed);
     }
-    memset(output_bytes_modbus_, 0, sizeof(output_bytes_modbus_));
+    std::memset(output_bytes_modbus_, 0, sizeof(output_bytes_modbus_));
 }
 
 uint8_t Communication::get_input_byte(InputBytes index) {

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -5,12 +5,7 @@
 
 namespace robotiq_hande_driver {
 
-Communication::Communication()
-    : cfg_{},
-      mb_{nullptr},
-      input_bytes_{},  // TODO setup proper initial values
-      output_bytes_{},
-      th_comm_enabled_{false} {}
+Communication::Communication() : cfg_{}, mb_{nullptr} {}
 
 Communication::~Communication() {
     cleanup();
@@ -20,25 +15,32 @@ void Communication::initialize(const CommunicationConfig& cfg) {
     cfg_ = cfg;
 }
 
-void Communication::read_write_registers() {
-    int result = 0;
-    while(th_comm_enabled_) {
-        {
-            std::lock_guard<std::mutex> lock(mtx_);
-            result = modbus_write_and_read_registers(
-                mb_,
-                GRIPPER_INPUT_FIRST_REG,
-                OUTPUT_REGISTER_WORD_LENGTH,
-                reinterpret_cast<uint16_t*>(output_bytes_.data()),
-                GRIPPER_OUTPUT_FIRST_REG,
-                INPUT_REGISTER_WORD_LENGTH,
-                reinterpret_cast<uint16_t*>(input_bytes_.data()));
-        }
-        if(result == FAILURE_MODBUS)
-            std::cout << "[WARNING] Failed to read & write Hand-e registers via modbus\n";
+InputBuffer Communication::read() const {
+    // TODO consider allocation of the buffer just once
+    InputBuffer regs{};
 
-        std::this_thread::sleep_for(cfg_.th_sleep_rate);
-    }
+    auto result = modbus_read_registers(
+        mb_,
+        GRIPPER_INPUT_FIRST_REG,
+        INPUT_REGISTER_WORD_LENGTH,
+        reinterpret_cast<uint16_t*>(regs.data()));
+
+    if(result == FAILURE_MODBUS)
+        throw CommunicationError("Failed to read registers (Modbus failure)");
+    if(result != INPUT_REGISTER_WORD_LENGTH)
+        throw CommunicationError("Failed to read all requested registers");
+
+    return regs;
+}
+
+void Communication::write(const OutputBuffer& regs) const {
+    auto result = modbus_write_registers(
+        mb_, GRIPPER_OUTPUT_FIRST_REG, OUTPUT_REGISTER_WORD_LENGTH, regs.data());
+
+    if(result == FAILURE_MODBUS)
+        throw CommunicationError("Failed to read registers (Modbus failure)");
+    if(result != OUTPUT_REGISTER_WORD_LENGTH)
+        throw CommunicationError("Failed to read all requested registers");
 }
 
 void Communication::configure() {
@@ -50,20 +52,11 @@ void Communication::configure() {
     }
 
     connect();
-
-    if(!th_comm_enabled_) {
-        th_comm_enabled_.store(true, std::memory_order_relaxed);
-        th_comm_.emplace(&Communication::read_write_registers, this);
-    }
 }
 
 void Communication::cleanup() {
-    th_comm_enabled_.store(false, std::memory_order_relaxed);
-    if(th_comm_ && th_comm_->joinable()) {
-        th_comm_->join();
-    }
-
     if(mb_ == nullptr) return;
+
     disconnect();
     modbus_free(mb_);
     mb_ = nullptr;
@@ -71,22 +64,11 @@ void Communication::cleanup() {
 
 void Communication::connect() {
     auto result = modbus_connect(mb_);
-    if(result == FAILURE_MODBUS)
-        throw CommunicationError("[robotiq_hande_driver] Failed to establish Modbus connection.");
+    if(result == FAILURE_MODBUS) throw CommunicationError("Failed to establish Modbus connection");
 }
 
 void Communication::disconnect() {
     modbus_close(mb_);
-}
-
-InputBuffer Communication::get_input_bytes() const {
-    std::lock_guard<std::mutex> lock(mtx_);
-    return input_bytes_;
-}
-
-void Communication::set_output_bytes(const OutputBuffer& vals) {
-    std::lock_guard<std::mutex> lock(mtx_);
-    output_bytes_ = vals;
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -7,13 +7,105 @@ namespace robotiq_hande_driver {
 Communication::Communication()
     : input_bytes_modbus_{}, output_bytes_modbus_{}, input_bytes_{}, output_bytes_{} {}
 
+Communication::~Communication() {
+    cleanup();
+}
+
+void Communication::initialize(
+    const std::string& tty_port,
+    int baudrate,
+    char parity,
+    int data_bits,
+    int stop_bit,
+    int slave_id) {
+    tty_port_ = tty_port.c_str();
+    baudrate_ = baudrate;
+    parity_ = parity;
+    data_bits_ = data_bits;
+    stop_bit_ = stop_bit;
+    slave_id_ = slave_id;
+}
+
+void Communication::read_write_registers() {
+    while(bg_comm_enabled_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
+            output_bytes_modbus_[i] = output_bytes_[i].load(std::memory_order_relaxed);
+        }
+
+        modbus_write_and_read_registers(
+            mb_,
+            GRIPPER_INPUT_FIRST_REG,
+            OUTPUT_REGISTER_WORD_LENGTH,
+            reinterpret_cast<uint16_t*>(output_bytes_modbus_),
+            GRIPPER_OUTPUT_FIRST_REG,
+            INPUT_REGISTER_WORD_LENGTH,
+            reinterpret_cast<uint16_t*>(input_bytes_modbus_));
+
+        for(size_t i = 0; i < NUM_OF_INPUT_BYTES; ++i) {
+            input_bytes_[i].store(input_bytes_modbus_[i], std::memory_order_relaxed);
+        }
+    }
+}
+
+int Communication::configure() {
+    mb_ = modbus_new_rtu(tty_port_, baudrate_, parity_, data_bits_, stop_bit_);
+    modbus_set_slave(mb_, slave_id_);
+    modbus_set_debug(mb_, DEBUG_MODBUS);
+    auto result = connect();
+
+    bg_comm_.emplace(&Communication::read_write_registers, this);
+
+    return result;
+}
+
+void Communication::cleanup() {
+    bg_comm_enabled_.store(false, std::memory_order_relaxed);
+    if(bg_comm_ && bg_comm_->joinable()) {
+        bg_comm_->join();
+    }
+
+    disconnect();
+    modbus_free(mb_);
+}
+
 int Communication::connect() {
-    // int result;
+    return modbus_connect(mb_);
+}
 
-    modbus_connect(mb_);
+void Communication::disconnect() {
+    modbus_close(mb_);
+}
 
-    // read_write_registers();
+void Communication::clear_output_bytes() {
+    for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
+        output_bytes_[i].store(0, std::memory_order_relaxed);
+    }
+    memset(output_bytes_modbus_, 0, sizeof(output_bytes_modbus_));
+}
 
-    return 0;
+uint8_t Communication::get_input_byte(InputBytes index) {
+    auto idx = static_cast<uint>(index);
+    return input_bytes_[idx].load(std::memory_order_relaxed);
+}
+
+void Communication::set_output_byte(OutputBytes index, uint8_t value) {
+    auto idx = static_cast<uint>(index);
+    output_bytes_[idx].store(value, std::memory_order_relaxed);
+}
+
+void Communication::write_action_bit(uint8_t position_bit, bool value) {
+    auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST;
+    auto reg = output_bytes_[idx].load(std::memory_order_relaxed);
+    auto result = bit_set_to(reg, position_bit, value);
+
+    output_bytes_[idx].store(result, std::memory_order_relaxed);
+}
+
+uint Communication::bit_set_to(uint value, uint n, bool x) {
+    uint reset_n_bit = ~(1u << n);
+    uint set_n_bit = static_cast<uint>(x) << n;
+    return (value & reset_n_bit) | set_n_bit;
 }
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -17,7 +17,7 @@ Communication::Communication()
       output_bytes_modbus_{},
       input_bytes_{},
       output_bytes_{},
-      bg_comm_enabled_{true} {}
+      bg_comm_enabled_{false} {}
 
 Communication::~Communication() {
     cleanup();
@@ -41,6 +41,7 @@ void Communication::initialize(
 void Communication::read_write_registers() {
     int result = 0;
     while(bg_comm_enabled_) {
+        // TODO parametrize the sleep time
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         for(size_t i = 0; i < NUM_OF_OUTPUT_BYTES; ++i) {
@@ -72,8 +73,10 @@ int Communication::configure() {
     // socat)
     auto result = connect();
 
-    bg_comm_enabled_.store(true, std::memory_order_relaxed);
-    bg_comm_.emplace(&Communication::read_write_registers, this);
+    if(!bg_comm_enabled_) {
+        bg_comm_enabled_.store(true, std::memory_order_relaxed);
+        bg_comm_.emplace(&Communication::read_write_registers, this);
+    }
 
     return result;
 }

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -1,8 +1,5 @@
 #include "robotiq_hande_driver/communication.hpp"
 
-#include <cstring>
-#include <iostream>
-
 namespace robotiq_hande_driver {
 
 Communication::Communication() : cfg_{}, mb_{nullptr} {}

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -41,7 +41,7 @@ void Communication::read_write_registers() {
     }
 }
 
-int Communication::configure() {
+void Communication::configure() {
     if(mb_ == nullptr) {
         mb_ = modbus_new_rtu(
             cfg_.tty_port.c_str(), cfg_.baudrate, cfg_.parity, cfg_.data_bits, cfg_.stop_bit);
@@ -49,18 +49,12 @@ int Communication::configure() {
         modbus_set_debug(mb_, DEBUG_MODBUS);
     }
 
-    auto result = connect();
-    if(result == FAILURE_MODBUS) {
-        std::cout << "[WARNING] [robotiq_hande_driver] Failed to establish Modbus connection.\n";
-        return FAILURE_MODBUS;
-    }
+    connect();
 
     if(!th_comm_enabled_) {
         th_comm_enabled_.store(true, std::memory_order_relaxed);
         th_comm_.emplace(&Communication::read_write_registers, this);
     }
-
-    return result;
 }
 
 void Communication::cleanup() {
@@ -75,9 +69,10 @@ void Communication::cleanup() {
     mb_ = nullptr;
 }
 
-int Communication::connect() {
+void Communication::connect() {
     auto result = modbus_connect(mb_);
-    return result;
+    if(result == FAILURE_MODBUS)
+        throw CommunicationError("[robotiq_hande_driver] Failed to establish Modbus connection.");
 }
 
 void Communication::disconnect() {

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -6,39 +6,23 @@
 namespace robotiq_hande_driver {
 
 Communication::Communication()
-    : tty_port_{},
-      baudrate_{},
-      parity_{},
-      data_bits_{},
-      stop_bit_{},
-      slave_id_{},
+    : cfg_{},
       mb_{nullptr},
       input_bytes_{},  // TODO setup proper initial values
       output_bytes_{},
-      bg_comm_enabled_{false} {}
+      th_comm_enabled_{false} {}
 
 Communication::~Communication() {
     cleanup();
 }
 
-void Communication::initialize(
-    const std::string& tty_port,
-    int baudrate,
-    char parity,
-    int data_bits,
-    int stop_bit,
-    int slave_id) {
-    tty_port_ = tty_port;
-    baudrate_ = baudrate;
-    parity_ = parity;
-    data_bits_ = data_bits;
-    stop_bit_ = stop_bit;
-    slave_id_ = slave_id;
+void Communication::initialize(const CommunicationConfig& cfg) {
+    cfg_ = cfg;
 }
 
 void Communication::read_write_registers() {
     int result = 0;
-    while(bg_comm_enabled_) {
+    while(th_comm_enabled_) {
         {
             std::lock_guard<std::mutex> lock(mtx_);
             result = modbus_write_and_read_registers(
@@ -53,15 +37,15 @@ void Communication::read_write_registers() {
         if(result == FAILURE_MODBUS)
             std::cout << "[WARNING] Failed to read & write Hand-e registers via modbus\n";
 
-        // TODO parametrize the sleep time
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(cfg_.th_sleep_rate);
     }
 }
 
 int Communication::configure() {
     if(mb_ == nullptr) {
-        mb_ = modbus_new_rtu(tty_port_.c_str(), baudrate_, parity_, data_bits_, stop_bit_);
-        modbus_set_slave(mb_, slave_id_);
+        mb_ = modbus_new_rtu(
+            cfg_.tty_port.c_str(), cfg_.baudrate, cfg_.parity, cfg_.data_bits, cfg_.stop_bit);
+        modbus_set_slave(mb_, cfg_.slave_id);
         modbus_set_debug(mb_, DEBUG_MODBUS);
     }
     // TODO: asynchronously connect to the modbus TCP (wait for a virtual serial port creation from
@@ -72,9 +56,9 @@ int Communication::configure() {
         return FAILURE_MODBUS;
     }
 
-    if(!bg_comm_enabled_) {
-        bg_comm_enabled_.store(true, std::memory_order_relaxed);
-        bg_comm_.emplace(&Communication::read_write_registers, this);
+    if(!th_comm_enabled_) {
+        th_comm_enabled_.store(true, std::memory_order_relaxed);
+        th_comm_.emplace(&Communication::read_write_registers, this);
     }
 
     // TODO do we really need the result?
@@ -83,9 +67,9 @@ int Communication::configure() {
 }
 
 void Communication::cleanup() {
-    bg_comm_enabled_.store(false, std::memory_order_relaxed);
-    if(bg_comm_ && bg_comm_->joinable()) {
-        bg_comm_->join();
+    th_comm_enabled_.store(false, std::memory_order_relaxed);
+    if(th_comm_ && th_comm_->joinable()) {
+        th_comm_->join();
     }
 
     if(mb_ == nullptr) return;
@@ -103,12 +87,12 @@ void Communication::disconnect() {
     modbus_close(mb_);
 }
 
-std::array<uint8_t, NUM_OF_INPUT_BYTES> Communication::get_input_bytes() const {
+InputBuffer Communication::get_input_bytes() const {
     std::lock_guard<std::mutex> lock(mtx_);
     return input_bytes_;
 }
 
-void Communication::set_output_bytes(const std::array<uint8_t, NUM_OF_OUTPUT_BYTES>& vals) {
+void Communication::set_output_bytes(const OutputBuffer& vals) {
     std::lock_guard<std::mutex> lock(mtx_);
     output_bytes_ = vals;
 }

--- a/robotiq_hande_driver/hardware/src/communication.cpp
+++ b/robotiq_hande_driver/hardware/src/communication.cpp
@@ -15,10 +15,7 @@ void Communication::initialize(const CommunicationConfig& cfg) {
     cfg_ = cfg;
 }
 
-InputBuffer Communication::read() const {
-    // TODO consider allocation of the buffer just once
-    InputBuffer regs{};
-
+void Communication::read(InputBuffer& regs) const {
     auto result = modbus_read_registers(
         mb_,
         GRIPPER_INPUT_FIRST_REG,
@@ -29,13 +26,14 @@ InputBuffer Communication::read() const {
         throw CommunicationError("Failed to read registers (Modbus failure)");
     if(result != INPUT_REGISTER_WORD_LENGTH)
         throw CommunicationError("Failed to read all requested registers");
-
-    return regs;
 }
 
-void Communication::write(const OutputBuffer& regs) const {
+void Communication::write(OutputBuffer& regs) const {
     auto result = modbus_write_registers(
-        mb_, GRIPPER_OUTPUT_FIRST_REG, OUTPUT_REGISTER_WORD_LENGTH, regs.data());
+        mb_,
+        GRIPPER_OUTPUT_FIRST_REG,
+        OUTPUT_REGISTER_WORD_LENGTH,
+        reinterpret_cast<uint16_t*>(regs.data()));
 
     if(result == FAILURE_MODBUS)
         throw CommunicationError("Failed to read registers (Modbus failure)");

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -17,18 +17,11 @@ HandeGripper::HandeGripper()
       gripper_postion_step_{} {}
 
 void HandeGripper::initialize(
-    double gripper_position_min,
-    double gripper_position_max,
-    const std::string& tty_port,
-    int baudrate,
-    char parity,
-    int data_bits,
-    int stop_bit,
-    int slave_id) {
+    double gripper_position_min, double gripper_position_max, const CommunicationConfig& cfg) {
     gripper_position_min_ = gripper_position_min;
     gripper_position_max_ = gripper_position_max;
     gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;
-    protocol_logic_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
+    protocol_logic_.initialize(cfg);
 }
 
 int HandeGripper::configure() {
@@ -109,7 +102,6 @@ double HandeGripper::get_current() const {
 void HandeGripper::read() {
     protocol_logic_.read_input_bytes();
 
-    // TODO consider extracting status to one level below (protocol_logic)
     status_.is_reset = protocol_logic_.is_reset();
     status_.is_ready = protocol_logic_.is_ready();
     status_.is_moving = protocol_logic_.is_moving();
@@ -126,7 +118,7 @@ void HandeGripper::read() {
 }
 
 void HandeGripper::write() {
-    // Do nothing?
+    protocol_logic_.write_output_bytes();
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -24,8 +24,8 @@ void HandeGripper::initialize(
     protocol_logic_.initialize(cfg);
 }
 
-int HandeGripper::configure() {
-    return protocol_logic_.configure();
+void HandeGripper::configure() {
+    protocol_logic_.configure();
 }
 
 void HandeGripper::cleanup() {

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -1,7 +1,9 @@
 #include "robotiq_hande_driver/hande_gripper.hpp"
 
+#include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <thread>
 
 namespace robotiq_hande_driver {
 
@@ -46,6 +48,8 @@ void HandeGripper::auto_release() {
 
 void HandeGripper::activate() {
     protocol_logic_.activate();
+    // TODO set it by an experiment
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 void HandeGripper::deactivate() {

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -1,5 +1,6 @@
-#include "robotiq_hande_driver/application.hpp"
+#include "robotiq_hande_driver/hande_gripper.hpp"
 
+#include <cmath>
 #include <cstdio>
 
 namespace robotiq_hande_driver {
@@ -23,7 +24,7 @@ void HandeGripper::initialize(
     char parity,
     int data_bits,
     int stop_bit,
-    protocol_logic_ int slave_id) {
+    int slave_id) {
     gripper_position_min_ = gripper_position_min;
     gripper_position_max_ = gripper_position_max;
     gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -8,7 +8,7 @@
 namespace robotiq_hande_driver {
 
 HandeGripper::HandeGripper()
-    : protocol_logic_{},
+    : prot_{},
       status_{},
       fault_status_{},
       requested_position_{},
@@ -23,37 +23,37 @@ void HandeGripper::initialize(
     gripper_position_min_ = gripper_position_min;
     gripper_position_max_ = gripper_position_max;
     gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;
-    protocol_logic_.initialize(cfg);
+    prot_.initialize(cfg);
 }
 
 void HandeGripper::configure() {
-    protocol_logic_.configure();
+    prot_.configure();
 }
 
 void HandeGripper::cleanup() {
-    protocol_logic_.cleanup();
+    prot_.cleanup();
 }
 
 void HandeGripper::stop() {
-    protocol_logic_.stop();
+    prot_.stop();
 }
 
 void HandeGripper::reset() {
-    protocol_logic_.reset();
+    prot_.reset();
 }
 
 void HandeGripper::auto_release() {
-    protocol_logic_.auto_release();
+    prot_.auto_release();
 }
 
 void HandeGripper::activate() {
-    protocol_logic_.activate();
+    prot_.activate();
     // TODO set it by an experiment
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 void HandeGripper::deactivate() {
-    protocol_logic_.reset();
+    prot_.reset();
 }
 
 void HandeGripper::shutdown() {
@@ -93,7 +93,7 @@ void HandeGripper::set_position(double position, double force) {
     if(!std::isnan(prev_force) && std::fabs(force - prev_force) < EPSILON) return;
 
     uint8_t scaled_force = static_cast<uint8_t>(force * MAX_FORCE);
-    protocol_logic_.go_to(
+    prot_.go_to(
         (uint8_t)((gripper_position_max_ - position) / gripper_postion_step_),
         MAX_SPEED,
         scaled_force);
@@ -104,25 +104,25 @@ double HandeGripper::get_current() const {
 }
 
 void HandeGripper::read() {
-    protocol_logic_.read_input_bytes();
+    prot_.read_input_bytes();
 
-    status_.is_reset = protocol_logic_.is_reset();
-    status_.is_ready = protocol_logic_.is_ready();
-    status_.is_moving = protocol_logic_.is_moving();
-    status_.is_stopped = protocol_logic_.is_stopped();
-    status_.is_opened = protocol_logic_.is_opened();
-    status_.is_closed = protocol_logic_.is_closed();
-    status_.object_detected = protocol_logic_.obj_detected();
+    status_.is_reset = prot_.is_reset();
+    status_.is_ready = prot_.is_ready();
+    status_.is_moving = prot_.is_moving();
+    status_.is_stopped = prot_.is_stopped();
+    status_.is_opened = prot_.is_opened();
+    status_.is_closed = prot_.is_closed();
+    status_.object_detected = prot_.obj_detected();
 
     // fault_status
     requested_position_ = gripper_position_max_
-                          - (double)protocol_logic_.get_reg_pos() * gripper_postion_step_;
-    position_ = gripper_position_max_ - (double)protocol_logic_.get_pos() * gripper_postion_step_;
-    current_ = (double)protocol_logic_.get_current() * GRIPPER_CURRENT_SCALE;
+                          - (double)prot_.get_raw_requested_pos() * gripper_postion_step_;
+    position_ = gripper_position_max_ - (double)prot_.get_raw_pos() * gripper_postion_step_;
+    current_ = (double)prot_.get_raw_current() * GRIPPER_CURRENT_SCALE;
 }
 
 void HandeGripper::write() {
-    protocol_logic_.write_output_bytes();
+    prot_.write_output_bytes();
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -4,7 +4,7 @@
 
 namespace robotiq_hande_driver {
 
-GripperApplication::GripperApplication()
+HandeGripper::HandeGripper()
     : protocol_logic_{},
       status_{},
       fault_status_{},
@@ -15,7 +15,7 @@ GripperApplication::GripperApplication()
       gripper_position_max_{},
       gripper_postion_step_{} {}
 
-void GripperApplication::initialize(
+void HandeGripper::initialize(
     double gripper_position_min,
     double gripper_position_max,
     const std::string& tty_port,
@@ -23,71 +23,77 @@ void GripperApplication::initialize(
     char parity,
     int data_bits,
     int stop_bit,
-    int slave_id) {
+    protocol_logic_ int slave_id) {
     gripper_position_min_ = gripper_position_min;
     gripper_position_max_ = gripper_position_max;
     gripper_postion_step_ = (gripper_position_max_ - gripper_position_min_) / 255.0;
     protocol_logic_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
 }
 
-int GripperApplication::configure() {
+int HandeGripper::configure() {
     return protocol_logic_.configure();
 }
 
-void GripperApplication::cleanup() {
+void HandeGripper::cleanup() {
     protocol_logic_.cleanup();
 }
 
-void GripperApplication::stop() {
+void HandeGripper::stop() {
     protocol_logic_.stop();
 }
 
-void GripperApplication::reset() {
+void HandeGripper::reset() {
     protocol_logic_.reset();
 }
 
-void GripperApplication::auto_release() {
+void HandeGripper::auto_release() {
     protocol_logic_.auto_release();
 }
 
-void GripperApplication::activate() {
+void HandeGripper::activate() {
     protocol_logic_.activate();
 }
 
-void GripperApplication::deactivate() {
+void HandeGripper::deactivate() {
     protocol_logic_.reset();
 }
 
-void GripperApplication::shutdown() {
+void HandeGripper::shutdown() {
     deactivate();
     cleanup();
 }
 
-void GripperApplication::open() {
+void HandeGripper::open() {
     set_position(gripper_position_max_);
 }
 
-void GripperApplication::close() {
+void HandeGripper::close() {
     set_position(gripper_position_min_);
 }
 
-GripperApplication::Status GripperApplication::get_status() const {
+HandeGripper::Status HandeGripper::get_status() const {
     return status_;
 }
 
-GripperApplication::FaultStatus GripperApplication::get_fault_status() const {
+HandeGripper::FaultStatus HandeGripper::get_fault_status() const {
     return fault_status_;
 }
 
-double GripperApplication::get_requested_position() const {
+double HandeGripper::get_requested_position() const {
     return requested_position_;
 }
 
-double GripperApplication::get_position() const {
+double HandeGripper::get_position() const {
     return position_;
 }
 
-void GripperApplication::set_position(double position, double force) {
+void HandeGripper::set_position(double position, double force) {
+    static double prev_position = std::numeric_limits<double>::quiet_NaN();
+    static double prev_force = std::numeric_limits<double>::quiet_NaN();
+
+    if(!std::isnan(prev_position) && std::fabs(position - prev_position) < EPSILON) return;
+    if(!std::isnan(prev_force) && std::fabs(force - prev_force) < EPSILON) return;
+
     uint8_t scaled_force = static_cast<uint8_t>(force * MAX_FORCE);
     protocol_logic_.go_to(
         (uint8_t)((gripper_position_max_ - position) / gripper_postion_step_),
@@ -95,13 +101,14 @@ void GripperApplication::set_position(double position, double force) {
         scaled_force);
 }
 
-double GripperApplication::get_current() const {
+double HandeGripper::get_current() const {
     return current_;
 }
 
-void GripperApplication::read() {
-    protocol_logic_.refresh_registers();
+void HandeGripper::read() {
+    protocol_logic_.read_input_bytes();
 
+    // TODO consider extracting status to one level below (protocol_logic)
     status_.is_reset = protocol_logic_.is_reset();
     status_.is_ready = protocol_logic_.is_ready();
     status_.is_moving = protocol_logic_.is_moving();
@@ -117,12 +124,8 @@ void GripperApplication::read() {
     current_ = (double)protocol_logic_.get_current() * GRIPPER_CURRENT_SCALE;
 }
 
-void GripperApplication::write() {
-    // TODO investigate: we shouldn't read statue during the write phase
-    protocol_logic_.refresh_registers();
-
-    // Here we should take internal registers and send them to the gripper
-    //  I.e. call set_position()
+void HandeGripper::write() {
+    // Do nothing?
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -48,8 +48,6 @@ void HandeGripper::auto_release() {
 
 void HandeGripper::activate() {
     prot_.activate();
-    // TODO set it by an experiment
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }
 
 void HandeGripper::deactivate() {

--- a/robotiq_hande_driver/hardware/src/hande_gripper.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_gripper.cpp
@@ -1,9 +1,6 @@
 #include "robotiq_hande_driver/hande_gripper.hpp"
 
-#include <chrono>
 #include <cmath>
-#include <cstdio>
-#include <thread>
 
 namespace robotiq_hande_driver {
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -79,10 +79,15 @@ void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
-    RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
+    RCLCPP_INFO(get_logger(), "%sConnecting to ModbusRTU%s", color::BCYAN, color::RESET);
 
     for(int iter = 0; iter < RECONNECT_MAX_ITER; iter++) {
-        RCLCPP_DEBUG(get_logger(), "Reconfiguring Hand-E Gripper attempt: %d", iter);
+        RCLCPP_DEBUG(
+            get_logger(),
+            "%sReconfiguring Hand-E Gripper attempt: %d%s",
+            color::BCYAN,
+            iter,
+            color::RESET);
 
         try {
             gripper_driver_.configure();
@@ -90,7 +95,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
             return HWI::CallbackReturn::SUCCESS;
         } catch(const CommunicationError& e) {
             // TODO check if RCLCPP_WARN_STREAM exists
-            RCLCPP_WARN(get_logger(), "%s%s%s", color::YELLOW, e.what(), color::RESET);
+            RCLCPP_WARN(get_logger(), "%s%s%s", color::BYELLOW, e.what(), color::RESET);
         }
         wait_100ms();
         wait_100ms();
@@ -105,7 +110,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(
     const rlccp_lc::State& /*previous_state*/) {
     gripper_driver_.cleanup();
 
-    RCLCPP_INFO(get_logger(), "Cleaned up Hand-E connection");
+    RCLCPP_INFO(get_logger(), "%sCleaned up Hand-E connection%s", color::BCYAN, color::RESET);
     return HWI::CallbackReturn::SUCCESS;
 }
 
@@ -142,16 +147,17 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
     gripper_driver_.read();
 
     if(gripper_driver_.get_status().is_ready) {
-        RCLCPP_INFO(get_logger(), "Hand-E already activated");
+        RCLCPP_INFO(get_logger(), "%sHand-E already activated%s", color::BGREEN, color::RESET);
         return HWI::CallbackReturn::SUCCESS;
     }
 
-    RCLCPP_INFO(get_logger(), "Hand-E activation in progress");
+    RCLCPP_INFO(get_logger(), "%sHand-E activation in progress%s", color::BCYAN, color::RESET);
     gripper_driver_.activate();
 
     for(int iter = 0; iter < ACTIVATION_MAX_ITER; iter++) {
         if(gripper_driver_.get_status().is_ready) {
-            RCLCPP_INFO(get_logger(), "Hand-E successfully activated");
+            RCLCPP_INFO(
+                get_logger(), "%sHand-E successfully activated%s", color::BGREEN, color::RESET);
             return HWI::CallbackReturn::SUCCESS;
         }
 
@@ -176,7 +182,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(
     const rlccp_lc::State& /*previous_state*/) {
     gripper_driver_.deactivate();
 
-    RCLCPP_INFO(get_logger(), "Hand-E successfully deactivated");
+    RCLCPP_INFO(get_logger(), "%sHand-E successfully deactivated%s", color::BCYAN, color::RESET);
     return HWI::CallbackReturn::SUCCESS;
 }
 
@@ -184,13 +190,17 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_shutdown(
     const rlccp_lc::State& /*previous_state*/) {
     gripper_driver_.shutdown();
 
-    RCLCPP_INFO(get_logger(), "Hand-E shutdown");
+    RCLCPP_INFO(get_logger(), "%sHand-E shutdown%s", color::BCYAN, color::RESET);
     return HWI::CallbackReturn::SUCCESS;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(
     const rlccp_lc::State& /*previous_state*/) {
-    RCLCPP_INFO(get_logger(), "Handled error with FAILURE on purpose - check previous logs");
+    RCLCPP_INFO(
+        get_logger(),
+        "%sHandled error with FAILURE on purpose - check previous logs%s",
+        color::BYELLOW,
+        color::RESET);
     return HWI::CallbackReturn::FAILURE;
 }
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -209,6 +209,14 @@ HWI::return_type RobotiqHandeHardwareInterface::write(
     return hardware_interface::return_type::OK;
 }
 
+rclcpp::Logger RobotiqHandeHardwareInterface::get_logger() const {
+    return *logger_;
+}
+
+rclcpp::Clock::SharedPtr RobotiqHandeHardwareInterface::get_clock() const {
+    return clock_;
+}
+
 }  // namespace robotiq_hande_driver
 
 #include "pluginlib/class_list_macros.hpp"

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -42,11 +42,26 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 
     bool manage_virutal_serial = info_.hardware_parameters["virtual_tty"] == "true";
     if(manage_virutal_serial) {
-        socat_.emplace(SocatManager(
-            info_.hardware_parameters["ip_adress"],
-            std::stoi(info_.hardware_parameters["port"]),
-            info_.hardware_parameters["tty_port"], ));
+        auto ip_addr = info_.hardware_parameters["ip_adress"];
+        auto port = info_.hardware_parameters["port"];
+        auto tty_port = info_.hardware_parameters["tty_port"];
+
+        RCLCPP_INFO(
+            get_logger(),
+            "%sCreating a virtual serial port from ip:%s port:%s with socat%s",
+            color::BCYAN,
+            ip_addr.c_str(),
+            port.c_str(),
+            color::RESET);
+        socat_.emplace(SocatManager(ip_addr, std::stoi(port), tty_port));
         socat_->start();
+
+        RCLCPP_INFO(
+            get_logger(),
+            "%sVirtual serial port created at %s%s",
+            color::BGREEN,
+            tty_port.c_str(),
+            color::RESET);
     }
 
     initalize_gripper_driver();

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -27,6 +27,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
                            "RobotiqHandeHardwareInterface"));
     log_parsed_urdf_config();
 
+    th_comm_enabled_.store(false);
     state_velocity_ = 0.0;
     cmd_force_ = 1.0;
     gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
@@ -55,7 +56,6 @@ void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
 }
 
 void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
-    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
     auto cfg = CommunicationConfig{
         info_.hardware_parameters["tty_port"],
         std::stoi(info_.hardware_parameters["baudrate"]),
@@ -63,8 +63,10 @@ void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
         std::stoi(info_.hardware_parameters["data_bits"]),
         std::stoi(info_.hardware_parameters["stop_bit"]),
         std::stoi(info_.hardware_parameters["slave_id"]),
-        std::chrono::milliseconds(1000 / frequency_hz),  // th_sleep_rate
     };
+    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
+    th_sleep_rate_ = std::chrono::milliseconds(1000 / frequency_hz);
+
     gripper_driver_.initialize(gripper_position_min_, gripper_position_max_, cfg);
 
     RCLCPP_INFO(
@@ -95,7 +97,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
             gripper_driver_.configure();
             RCLCPP_INFO(get_logger(), "%sConnected%s", color::BGREEN, color::RESET);
             return HWI::CallbackReturn::SUCCESS;
-        } catch(const CommunicationError& e) {
+        } catch(const std::exception& e) {
             // TODO check if RCLCPP_WARN_STREAM exists
             RCLCPP_WARN(get_logger(), "%s%s%s", color::BYELLOW, e.what(), color::RESET);
         }
@@ -146,43 +148,70 @@ std::vector<HWI::CommandInterface> RobotiqHandeHardwareInterface::export_command
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
     const rlccp_lc::State& /*previous_state*/) {
-    gripper_driver_.read();
+    try {
+        gripper_driver_.deactivate();
+        gripper_driver_.activate();
 
-    if(gripper_driver_.get_status().is_ready) {
-        RCLCPP_INFO(get_logger(), "%sHand-E already activated%s", color::BGREEN, color::RESET);
-        return HWI::CallbackReturn::SUCCESS;
+        if(!th_comm_enabled_) {
+            th_comm_enabled_.store(true, std::memory_order_relaxed);
+            th_comm_.emplace(&RobotiqHandeHardwareInterface::gripper_communication, this);
+        }
+    } catch(const std::exception& e) {
+        RCLCPP_ERROR(
+            get_logger(),
+            "%sException during Hand-E activation: %s%s",
+            color::BRED,
+            e.what(),
+            color::RESET);
+        return HWI::CallbackReturn::ERROR;
     }
 
-    RCLCPP_INFO(get_logger(), "%sHand-E activation in progress%s", color::BCYAN, color::RESET);
-    gripper_driver_.activate();
+    RCLCPP_INFO(get_logger(), "%sHand-E successfully activated%s", color::BGREEN, color::RESET);
+    return HWI::CallbackReturn::SUCCESS;
+}
 
-    for(int iter = 0; iter < ACTIVATION_MAX_ITER; iter++) {
-        if(gripper_driver_.get_status().is_ready) {
-            RCLCPP_INFO(
-                get_logger(), "%sHand-E successfully activated%s", color::BGREEN, color::RESET);
-            return HWI::CallbackReturn::SUCCESS;
+void RobotiqHandeHardwareInterface::gripper_communication() {
+    while(th_comm_enabled_) {
+        try {
+            // Write to gripper driver
+            gripper_driver_.read();
+            read_position_.store(gripper_driver_.get_position());
+
+            // Read from gripper driver
+            gripper_driver_.set_position(write_position_.load(), write_force_.load());
+            gripper_driver_.write();
+
+        } catch(const std::exception& e) {
+            RCLCPP_WARN(
+                get_logger(),
+                "%sException during Hand-E background communication: %s%s",
+                color::BYELLOW,
+                e.what(),
+                color::RESET);
         }
 
-        RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
-            get_logger(),
-            *get_clock(),
-            THROTTLE_1000_MS,
-            "Waiting for activation to be finished, attempt %d of %d",
-            iter,
-            ACTIVATION_MAX_ITER);
-
-        wait_100ms();
-        gripper_driver_.read();
+        std::this_thread::sleep_for(th_sleep_rate_);
     }
-
-    RCLCPP_ERROR(
-        get_logger(), "%sFailed to activate Hand-E (Timeout)%s", color::BRED, color::RESET);
-    return HWI::CallbackReturn::FAILURE;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(
     const rlccp_lc::State& /*previous_state*/) {
-    gripper_driver_.deactivate();
+    th_comm_enabled_.store(false, std::memory_order_relaxed);
+    if(th_comm_ && th_comm_->joinable()) {
+        th_comm_->join();
+    }
+
+    try {
+        gripper_driver_.deactivate();
+    } catch(const std::exception& e) {
+        RCLCPP_ERROR(
+            get_logger(),
+            "%sException during Hand-E deactivation: %s%s",
+            color::BRED,
+            e.what(),
+            color::RESET);
+        return HWI::CallbackReturn::ERROR;
+    }
 
     RCLCPP_INFO(get_logger(), "%sHand-E successfully deactivated%s", color::BCYAN, color::RESET);
     return HWI::CallbackReturn::SUCCESS;
@@ -201,22 +230,24 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(
     RCLCPP_INFO(
         get_logger(),
         "%sHandled error with FAILURE on purpose - check previous logs%s",
-        color::BYELLOW,
+        color::BRED,
         color::RESET);
     return HWI::CallbackReturn::FAILURE;
 }
 
 HWI::return_type RobotiqHandeHardwareInterface::read(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-    gripper_driver_.read();
-    state_position_ = gripper_driver_.get_position();
+    // TODO should we use mutexes?
+    state_position_ = read_position_.load();
+    state_velocity_ = read_velocity_.load();
 
     return hardware_interface::return_type::OK;
 }
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-    gripper_driver_.set_position(cmd_position_, cmd_force_);
-    gripper_driver_.write();
+    write_position_.store(cmd_position_);
+    write_force_.store(cmd_force_);
+
     return hardware_interface::return_type::OK;
 }
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -25,7 +25,39 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     logger_ = std::make_shared<rclcpp::Logger>(
         rclcpp::get_logger("controller_manager.resource_manager.hardware_component.system."
                            "RobotiqHandeHardwareInterface"));
+    log_parsed_urdf_config();
 
+    state_velocity_ = 0.0;
+    cmd_force_ = 1.0;
+    gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
+    gripper_position_max_ = std::stod(info_.hardware_parameters["grip_pos_max"]);
+
+    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
+    auto cfg = CommunicationConfig{
+        info_.hardware_parameters["tty"],  // TODO change name to tty_port
+        std::stoi(info_.hardware_parameters["baudrate"])(
+            info_.hardware_parameters["parity"].c_str())[0],
+        std::stoi(info_.hardware_parameters["data_bits"]),
+        std::stoi(info_.hardware_parameters["stop_bit"]),
+        std::stoi(info_.hardware_parameters["slave_id"]),
+        std::chrono::milliseconds(1000 / frequency_hz),  // th_sleep_rate
+    };
+
+    cmd_position_ = gripper_position_max_;
+    state_position_ = gripper_position_max_;
+    gripper_driver_.initialize(cfg);
+
+    RCLCPP_INFO(
+        get_logger(),
+        "Initialized ModbusRTU for %s, %d, %c, %d, %d",
+        cfg.tty_port.c_str(),
+        cfg.baudrate,
+        cfg.parity,
+        cfg.data_bits,
+        cfg.stop_bit);
+    return HWI::CallbackReturn::SUCCESS;
+}
+void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
     RCLCPP_DEBUG(
         get_logger(), "grip_pos_min: %s", info_.hardware_parameters["grip_pos_min"].c_str());
     RCLCPP_DEBUG(
@@ -36,40 +68,8 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     RCLCPP_DEBUG(get_logger(), "data_bits: %s", info_.hardware_parameters["data_bits"].c_str());
     RCLCPP_DEBUG(get_logger(), "stop_bit:  %s", info_.hardware_parameters["stop_bit"].c_str());
     RCLCPP_DEBUG(get_logger(), "slave_id: %s", info_.hardware_parameters["slave_id"].c_str());
-
-    state_velocity_ = 0.0;
-    cmd_force_ = 1.0;
-    gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
-    gripper_position_max_ = std::stod(info_.hardware_parameters["grip_pos_max"]);
-    tty_port_ = info_.hardware_parameters["tty"];
-    baudrate_ = std::stoi(info_.hardware_parameters["baudrate"]);
-    parity_ = (info_.hardware_parameters["parity"].c_str())[0];
-    data_bits_ = std::stoi(info_.hardware_parameters["data_bits"]);
-    stop_bit_ = std::stoi(info_.hardware_parameters["stop_bit"]);
-    slave_id_ = std::stoi(info_.hardware_parameters["slave_id"]);
-
-    cmd_position_ = gripper_position_max_;
-    state_position_ = gripper_position_max_;
-
-    gripper_driver_.initialize(
-        gripper_position_min_,
-        gripper_position_max_,
-        tty_port_,
-        baudrate_,
-        parity_,
-        data_bits_,
-        stop_bit_,
-        slave_id_);
-
-    RCLCPP_INFO(
-        get_logger(),
-        "Initialized ModbusRTU for %s, %d, %c, %d, %d",
-        tty_port_.c_str(),
-        baudrate_,
-        parity_,
-        data_bits_,
-        stop_bit_);
-    return HWI::CallbackReturn::SUCCESS;
+    RCLCPP_DEBUG(
+        get_logger(), "frequency_hz: %s", info_.hardware_parameters["frequency_hz"].c_str());
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
@@ -77,14 +77,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     int result = FAILURE_MODBUS;
 
     RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
-    RCLCPP_DEBUG(
-        get_logger(),
-        "Connecting to tty:%s, baudrate:%d, parity:%c, data_bits:%d, stop_bit:%d",
-        tty_port_.c_str(),
-        baudrate_,
-        parity_,
-        data_bits_,
-        stop_bit_);
 
     result = gripper_driver_.configure();
 
@@ -211,6 +203,7 @@ HWI::return_type RobotiqHandeHardwareInterface::read(
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
     gripper_driver_.set_position(cmd_position_, cmd_force_);
+    gripper_driver_.write();
     return hardware_interface::return_type::OK;
 }
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -39,7 +39,8 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
     th_sleep_rate_ = std::chrono::milliseconds(1000 / frequency_hz);
 
-    bool manage_virutal_serial = info_.hardware_parameters["virtual_tty"] == "true";
+    bool manage_virutal_serial = str_to_lower(info_.hardware_parameters["create_socat_tty"])
+                                 == "true";
     if(manage_virutal_serial) {
         auto ip_addr = info_.hardware_parameters["ip_adress"];
         auto port = info_.hardware_parameters["port"];

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -17,6 +17,10 @@ inline void wait_100ms() {
 
 RobotiqHandeHardwareInterface::RobotiqHandeHardwareInterface() {}
 
+RobotiqHandeHardwareInterface::~RobotiqHandeHardwareInterface() {
+    if(socat_ && socat_->is_alive()) socat_->stop();
+}
+
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareInfo& info) {
     if(HWI::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
         return HWI::CallbackReturn::ERROR;
@@ -32,6 +36,19 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     cmd_force_ = 1.0;
     gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
     gripper_position_max_ = std::stod(info_.hardware_parameters["grip_pos_max"]);
+
+    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
+    th_sleep_rate_ = std::chrono::milliseconds(1000 / frequency_hz);
+
+    bool manage_virutal_serial = info_.hardware_parameters["virtual_tty"] == "true";
+    if(manage_virutal_serial) {
+        socat_.emplace(SocatManager(
+            info_.hardware_parameters["ip_adress"],
+            std::stoi(info_.hardware_parameters["port"]),
+            info_.hardware_parameters["tty_port"], ));
+        socat_->start();
+    }
+
     initalize_gripper_driver();
 
     cmd_position_ = gripper_position_max_;
@@ -64,9 +81,6 @@ void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
         std::stoi(info_.hardware_parameters["stop_bit"]),
         std::stoi(info_.hardware_parameters["slave_id"]),
     };
-    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
-    th_sleep_rate_ = std::chrono::milliseconds(1000 / frequency_hz);
-
     gripper_driver_.initialize(gripper_position_min_, gripper_position_max_, cfg);
 
     RCLCPP_INFO(

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -3,13 +3,16 @@
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
+#include <thread>
+
 namespace robotiq_hande_driver {
 
 static constexpr auto THROTTLE_1000_MS = 1000;
-static constexpr auto ACTIVATION_MAX_ITER = 100;
+static constexpr auto ACTIVATION_MAX_ITER = 20;
 static constexpr auto RECONNECT_MAX_ITER = 10;
 inline void wait_100ms() {
-    usleep(100 * 1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
 
 RobotiqHandeHardwareInterface::RobotiqHandeHardwareInterface() {}
@@ -97,7 +100,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     }
 
     if(result == FAILURE_MODBUS) {
-        RCLCPP_INFO(get_logger(), "Failed to configure Hand-E Gripper");
+        RCLCPP_ERROR(get_logger(), "Failed to configure Hand-E Gripper");
         return HWI::CallbackReturn::FAILURE;
     }
 
@@ -146,25 +149,28 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
     int iter = 0;
     gripper_driver_.read();
 
-    if(gripper_driver_.get_status().is_ready)
+    if(gripper_driver_.get_status().is_ready) {
         RCLCPP_INFO(get_logger(), "Hand-E already active");
-    else {
-        RCLCPP_INFO(get_logger(), "Hand-E activation in progress");
-        gripper_driver_.activate();
+        return HWI::CallbackReturn::SUCCESS;
+    }
 
-        while(!gripper_driver_.get_status().is_ready) {
-            RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
-                get_logger(),
-                *get_clock(),
-                THROTTLE_1000_MS,
-                "Waiting for activation to be finished: %d",
-                iter);
-            wait_100ms();
-            gripper_driver_.read();
-            if(iter++ > ACTIVATION_MAX_ITER) {
-                RCLCPP_INFO(get_logger(), "Hand-E NOT activated, failure");
-                return HWI::CallbackReturn::FAILURE;
-            }
+    RCLCPP_INFO(get_logger(), "Hand-E activation in progress");
+    gripper_driver_.activate();
+
+    while(!gripper_driver_.get_status().is_ready) {
+        RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
+            get_logger(),
+            *get_clock(),
+            THROTTLE_1000_MS,
+            "Waiting for activation to be finished: %d",
+            iter);
+        wait_100ms();
+        gripper_driver_.read();
+        if(iter++ > ACTIVATION_MAX_ITER) {
+            // const std::string red     = "\033[31m";
+            // const std::string reset   = "\033[0m";
+            RCLCPP_ERROR(get_logger(), "\033[31mFailed to activate Hand-E (Timeout)\033[0m");
+            return HWI::CallbackReturn::FAILURE;
         }
     }
 
@@ -203,6 +209,9 @@ HWI::return_type RobotiqHandeHardwareInterface::read(
 }
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
+    // TODO Investigate better approach
+
+    // TODO stabilize connection (maybe its too fast?)
     gripper_driver_.set_position(cmd_position_, cmd_force_);
     gripper_driver_.write();
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -1,9 +1,8 @@
 #include "robotiq_hande_driver/hande_hardware_interface.hpp"
-
-#include <hardware_interface/types/hardware_interface_type_values.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include "robotiq_hande_driver/utils.hpp"
 
 #include <chrono>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
 #include <thread>
 
 namespace robotiq_hande_driver {
@@ -11,6 +10,7 @@ namespace robotiq_hande_driver {
 static constexpr auto THROTTLE_1000_MS = 1000;
 static constexpr auto ACTIVATION_MAX_ITER = 20;
 static constexpr auto RECONNECT_MAX_ITER = 10;
+
 inline void wait_100ms() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
@@ -79,31 +79,26 @@ void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
     const rlccp_lc::State& /*previous_state*/) {
-    int result = FAILURE_MODBUS;
-
     RCLCPP_INFO(get_logger(), "Connecting to ModbusRTU");
 
-    result = gripper_driver_.configure();
+    for(int iter = 0; iter < RECONNECT_MAX_ITER; iter++) {
+        RCLCPP_DEBUG(get_logger(), "Reconfiguring Hand-E Gripper attempt: %d", iter);
 
-    for(int iter = 0; result == FAILURE_MODBUS && iter < RECONNECT_MAX_ITER; iter++) {
-        RCLCPP_DEBUG(
-            get_logger(), "Reconfiguring Hand-E Gripper attempt: %d; result: %d", iter, result);
-
+        try {
+            gripper_driver_.configure();
+            RCLCPP_INFO(get_logger(), "Connected");
+            return HWI::CallbackReturn::SUCCESS;
+        } catch(const CommunicationError& e) {
+            // TODO check if RCLCPP_WARN_STREAM exists
+            RCLCPP_WARN(get_logger(), "%s%s%s", color::YELLOW, e.what(), color::RESET);
+        }
         wait_100ms();
         wait_100ms();
-
         gripper_driver_.cleanup();
-        result = gripper_driver_.configure();
     }
 
-    // TODO change passing result value to std::throw mechanism
-    if(result == FAILURE_MODBUS) {
-        RCLCPP_ERROR(get_logger(), "Failed to configure Hand-E Gripper");
-        return HWI::CallbackReturn::FAILURE;
-    }
-
-    RCLCPP_INFO(get_logger(), "Connected");
-    return HWI::CallbackReturn::SUCCESS;
+    RCLCPP_ERROR(get_logger(), "%sFailed to configure Hand-E Gripper%s", color::BRED, color::RESET);
+    return HWI::CallbackReturn::FAILURE;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_cleanup(
@@ -144,37 +139,37 @@ std::vector<HWI::CommandInterface> RobotiqHandeHardwareInterface::export_command
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
     const rlccp_lc::State& /*previous_state*/) {
-    int iter = 0;
     gripper_driver_.read();
 
     if(gripper_driver_.get_status().is_ready) {
-        RCLCPP_INFO(get_logger(), "Hand-E already active");
+        RCLCPP_INFO(get_logger(), "Hand-E already activated");
         return HWI::CallbackReturn::SUCCESS;
     }
 
     RCLCPP_INFO(get_logger(), "Hand-E activation in progress");
     gripper_driver_.activate();
 
-    while(!gripper_driver_.get_status().is_ready) {
+    for(int iter = 0; iter < ACTIVATION_MAX_ITER; iter++) {
+        if(gripper_driver_.get_status().is_ready) {
+            RCLCPP_INFO(get_logger(), "Hand-E successfully activated");
+            return HWI::CallbackReturn::SUCCESS;
+        }
+
         RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
             get_logger(),
             *get_clock(),
             THROTTLE_1000_MS,
-            "Waiting for activation to be finished: %d",
-            iter);
+            "Waiting for activation to be finished, attempt %d of %d",
+            iter,
+            ACTIVATION_MAX_ITER);
+
         wait_100ms();
         gripper_driver_.read();
-        if(iter++ > ACTIVATION_MAX_ITER) {
-            // TODO ADD COLOURS TO HIGH LEVEL LOGGING
-            //  const std::string red     = "\033[31m";
-            //  const std::string reset   = "\033[0m";
-            RCLCPP_ERROR(get_logger(), "\033[31mFailed to activate Hand-E (Timeout)\033[0m");
-            return HWI::CallbackReturn::FAILURE;
-        }
     }
 
-    RCLCPP_INFO(get_logger(), "Hand-E successfully activated");
-    return HWI::CallbackReturn::SUCCESS;
+    RCLCPP_ERROR(
+        get_logger(), "%sFailed to activate Hand-E (Timeout)%s", color::BRED, color::RESET);
+    return HWI::CallbackReturn::FAILURE;
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_deactivate(

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -2,9 +2,9 @@
 #include "robotiq_hande_driver/utils.hpp"
 
 #include <chrono>
-#include <hardware_interface/types/hardware_interface_type_values.hpp>
-#include <stdexcept>
 #include <thread>
+
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
 
 namespace robotiq_hande_driver {
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -44,7 +44,7 @@ void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
         get_logger(), "grip_pos_min: %s", info_.hardware_parameters["grip_pos_min"].c_str());
     RCLCPP_DEBUG(
         get_logger(), "grip_pos_max: %s", info_.hardware_parameters["grip_pos_max"].c_str());
-    RCLCPP_DEBUG(get_logger(), "tty: %s", info_.hardware_parameters["tty"].c_str());
+    RCLCPP_DEBUG(get_logger(), "tty_port: %s", info_.hardware_parameters["tty_port"].c_str());
     RCLCPP_DEBUG(get_logger(), "baudrate: %s", info_.hardware_parameters["baudrate"].c_str());
     RCLCPP_DEBUG(get_logger(), "parity: %s", info_.hardware_parameters["parity"].c_str());
     RCLCPP_DEBUG(get_logger(), "data_bits: %s", info_.hardware_parameters["data_bits"].c_str());
@@ -57,7 +57,7 @@ void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
 void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
     auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
     auto cfg = CommunicationConfig{
-        info_.hardware_parameters["tty"],  // TODO change name to tty_port
+        info_.hardware_parameters["tty_port"],
         std::stoi(info_.hardware_parameters["baudrate"]),
         (info_.hardware_parameters["parity"].c_str())[0],
         std::stoi(info_.hardware_parameters["data_bits"]),
@@ -69,12 +69,14 @@ void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
 
     RCLCPP_INFO(
         get_logger(),
-        "Initialized ModbusRTU for %s, %d, %c, %d, %d",
+        "%sInitialized ModbusRTU for %s, %d, %c, %d, %d%s",
+        color::BCYAN,
         cfg.tty_port.c_str(),
         cfg.baudrate,
         cfg.parity,
         cfg.data_bits,
-        cfg.stop_bit);
+        cfg.stop_bit,
+        color::RESET);
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
@@ -91,7 +93,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
 
         try {
             gripper_driver_.configure();
-            RCLCPP_INFO(get_logger(), "Connected");
+            RCLCPP_INFO(get_logger(), "%sConnected%s", color::BGREEN, color::RESET);
             return HWI::CallbackReturn::SUCCESS;
         } catch(const CommunicationError& e) {
             // TODO check if RCLCPP_WARN_STREAM exists

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -35,8 +35,8 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
     auto cfg = CommunicationConfig{
         info_.hardware_parameters["tty"],  // TODO change name to tty_port
-        std::stoi(info_.hardware_parameters["baudrate"])(
-            info_.hardware_parameters["parity"].c_str())[0],
+        std::stoi(info_.hardware_parameters["baudrate"]),
+        (info_.hardware_parameters["parity"].c_str())[0],
         std::stoi(info_.hardware_parameters["data_bits"]),
         std::stoi(info_.hardware_parameters["stop_bit"]),
         std::stoi(info_.hardware_parameters["slave_id"]),
@@ -45,7 +45,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 
     cmd_position_ = gripper_position_max_;
     state_position_ = gripper_position_max_;
-    gripper_driver_.initialize(cfg);
+    gripper_driver_.initialize(gripper_position_min_, gripper_position_max_, cfg);
 
     RCLCPP_INFO(
         get_logger(),

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -1,9 +1,6 @@
 #include "robotiq_hande_driver/hande_hardware_interface.hpp"
 #include "robotiq_hande_driver/utils.hpp"
 
-#include <chrono>
-#include <thread>
-
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
 
 namespace robotiq_hande_driver {

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <stdexcept>
 #include <thread>
 
 namespace robotiq_hande_driver {
@@ -32,8 +33,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     log_parsed_urdf_config();
 
     th_comm_enabled_.store(false);
-    state_velocity_ = 0.0;
-    cmd_force_ = 1.0;
     gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
     gripper_position_max_ = std::stod(info_.hardware_parameters["grip_pos_max"]);
 
@@ -55,6 +54,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
             color::RESET);
         socat_.emplace(SocatManager(ip_addr, std::stoi(port), tty_port));
         socat_->start();
+        std::this_thread::sleep_for(WAIT_FOR_SOCAT_CONNECTION);
 
         RCLCPP_INFO(
             get_logger(),
@@ -66,8 +66,15 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 
     initalize_gripper_driver();
 
-    cmd_position_ = gripper_position_max_;
     state_position_ = gripper_position_max_;
+    state_velocity_ = 0.0;
+    read_position_.store(state_position_);
+    read_velocity_.store(state_velocity_);
+
+    cmd_force_ = 1.0;
+    cmd_position_ = gripper_position_max_;
+    write_position_.store(cmd_position_);
+    write_force_.store(cmd_force_);
 
     return HWI::CallbackReturn::SUCCESS;
 }
@@ -127,7 +134,6 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
             RCLCPP_INFO(get_logger(), "%sConnected%s", color::BGREEN, color::RESET);
             return HWI::CallbackReturn::SUCCESS;
         } catch(const std::exception& e) {
-            // TODO check if RCLCPP_WARN_STREAM exists
             RCLCPP_WARN(get_logger(), "%s%s%s", color::BYELLOW, e.what(), color::RESET);
         }
         wait_100ms();

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -31,32 +31,14 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
     cmd_force_ = 1.0;
     gripper_position_min_ = std::stod(info_.hardware_parameters["grip_pos_min"]);
     gripper_position_max_ = std::stod(info_.hardware_parameters["grip_pos_max"]);
-
-    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
-    auto cfg = CommunicationConfig{
-        info_.hardware_parameters["tty"],  // TODO change name to tty_port
-        std::stoi(info_.hardware_parameters["baudrate"]),
-        (info_.hardware_parameters["parity"].c_str())[0],
-        std::stoi(info_.hardware_parameters["data_bits"]),
-        std::stoi(info_.hardware_parameters["stop_bit"]),
-        std::stoi(info_.hardware_parameters["slave_id"]),
-        std::chrono::milliseconds(1000 / frequency_hz),  // th_sleep_rate
-    };
+    initalize_gripper_driver();
 
     cmd_position_ = gripper_position_max_;
     state_position_ = gripper_position_max_;
-    gripper_driver_.initialize(gripper_position_min_, gripper_position_max_, cfg);
 
-    RCLCPP_INFO(
-        get_logger(),
-        "Initialized ModbusRTU for %s, %d, %c, %d, %d",
-        cfg.tty_port.c_str(),
-        cfg.baudrate,
-        cfg.parity,
-        cfg.data_bits,
-        cfg.stop_bit);
     return HWI::CallbackReturn::SUCCESS;
 }
+
 void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
     RCLCPP_DEBUG(
         get_logger(), "grip_pos_min: %s", info_.hardware_parameters["grip_pos_min"].c_str());
@@ -70,6 +52,29 @@ void RobotiqHandeHardwareInterface::log_parsed_urdf_config() {
     RCLCPP_DEBUG(get_logger(), "slave_id: %s", info_.hardware_parameters["slave_id"].c_str());
     RCLCPP_DEBUG(
         get_logger(), "frequency_hz: %s", info_.hardware_parameters["frequency_hz"].c_str());
+}
+
+void RobotiqHandeHardwareInterface::initalize_gripper_driver() {
+    auto frequency_hz = std::stoi(info_.hardware_parameters["frequency_hz"]);
+    auto cfg = CommunicationConfig{
+        info_.hardware_parameters["tty"],  // TODO change name to tty_port
+        std::stoi(info_.hardware_parameters["baudrate"]),
+        (info_.hardware_parameters["parity"].c_str())[0],
+        std::stoi(info_.hardware_parameters["data_bits"]),
+        std::stoi(info_.hardware_parameters["stop_bit"]),
+        std::stoi(info_.hardware_parameters["slave_id"]),
+        std::chrono::milliseconds(1000 / frequency_hz),  // th_sleep_rate
+    };
+    gripper_driver_.initialize(gripper_position_min_, gripper_position_max_, cfg);
+
+    RCLCPP_INFO(
+        get_logger(),
+        "Initialized ModbusRTU for %s, %d, %c, %d, %d",
+        cfg.tty_port.c_str(),
+        cfg.baudrate,
+        cfg.parity,
+        cfg.data_bits,
+        cfg.stop_bit);
 }
 
 HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
@@ -91,6 +96,7 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_configure(
         result = gripper_driver_.configure();
     }
 
+    // TODO change passing result value to std::throw mechanism
     if(result == FAILURE_MODBUS) {
         RCLCPP_ERROR(get_logger(), "Failed to configure Hand-E Gripper");
         return HWI::CallbackReturn::FAILURE;

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -167,8 +167,9 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
         wait_100ms();
         gripper_driver_.read();
         if(iter++ > ACTIVATION_MAX_ITER) {
-            // const std::string red     = "\033[31m";
-            // const std::string reset   = "\033[0m";
+            // TODO ADD COLOURS TO HIGH LEVEL LOGGING
+            //  const std::string red     = "\033[31m";
+            //  const std::string reset   = "\033[0m";
             RCLCPP_ERROR(get_logger(), "\033[31mFailed to activate Hand-E (Timeout)\033[0m");
             return HWI::CallbackReturn::FAILURE;
         }
@@ -209,12 +210,7 @@ HWI::return_type RobotiqHandeHardwareInterface::read(
 }
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-    // TODO Investigate better approach
-
-    // TODO stabilize connection (maybe its too fast?)
     gripper_driver_.set_position(cmd_position_, cmd_force_);
-    gripper_driver_.write();
-
     return hardware_interface::return_type::OK;
 }
 

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -173,16 +173,18 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_activate(
 void RobotiqHandeHardwareInterface::gripper_communication() {
     while(th_comm_enabled_) {
         try {
-            // Write to gripper driver
             gripper_driver_.read();
+
+            // TODO introduce mutex for manipulating all read values
             read_position_.store(gripper_driver_.get_position());
 
-            // Read from gripper driver
+            // TODO introduce mutex for manipulating all write values
             gripper_driver_.set_position(write_position_.load(), write_force_.load());
+
             gripper_driver_.write();
 
         } catch(const std::exception& e) {
-            RCLCPP_WARN(
+            RCLCPP_DEBUG(
                 get_logger(),
                 "%sException during Hand-E background communication: %s%s",
                 color::BYELLOW,

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -69,13 +69,13 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_init(const HWI::HardwareIn
 
     state_position_ = gripper_position_max_;
     state_velocity_ = 0.0;
-    read_position_.store(state_position_);
-    read_velocity_.store(state_velocity_);
+    read_position_ = state_position_;
+    read_velocity_ = state_velocity_;
 
     cmd_force_ = 1.0;
     cmd_position_ = gripper_position_max_;
-    write_position_.store(cmd_position_);
-    write_force_.store(cmd_force_);
+    write_position_ = cmd_position_;
+    write_force_ = cmd_force_;
 
     return HWI::CallbackReturn::SUCCESS;
 }
@@ -210,13 +210,15 @@ void RobotiqHandeHardwareInterface::gripper_communication() {
     while(th_comm_enabled_) {
         try {
             gripper_driver_.read();
+            {
+                std::lock_guard<std::mutex> lock(mtx_read_);
+                read_position_ = gripper_driver_.get_position();
+            }
 
-            // TODO introduce mutex for manipulating all read values
-            read_position_.store(gripper_driver_.get_position());
-
-            // TODO introduce mutex for manipulating all write values
-            gripper_driver_.set_position(write_position_.load(), write_force_.load());
-
+            {
+                std::lock_guard<std::mutex> lock(mtx_write_);
+                gripper_driver_.set_position(write_position_, write_force_);
+            }
             gripper_driver_.write();
 
         } catch(const std::exception& e) {
@@ -275,16 +277,19 @@ HWI::CallbackReturn RobotiqHandeHardwareInterface::on_error(
 
 HWI::return_type RobotiqHandeHardwareInterface::read(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-    // TODO should we use mutexes?
-    state_position_ = read_position_.load();
-    state_velocity_ = read_velocity_.load();
+    std::lock_guard<std::mutex> lock(mtx_read_);
+
+    state_position_ = read_position_;
+    state_velocity_ = read_velocity_;
 
     return hardware_interface::return_type::OK;
 }
 HWI::return_type RobotiqHandeHardwareInterface::write(
     const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-    write_position_.store(cmd_position_);
-    write_force_.store(cmd_force_);
+    std::lock_guard<std::mutex> lock(mtx_write_);
+
+    write_position_ = cmd_position_;
+    write_force_ = cmd_force_;
 
     return hardware_interface::return_type::OK;
 }

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -38,7 +38,6 @@ void ProtocolLogic::cleanup() {
 
 void ProtocolLogic::reset() {
     output_bytes_.fill(0);
-    write_output_bytes();
     write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
         static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
@@ -47,7 +46,6 @@ void ProtocolLogic::reset() {
 
 void ProtocolLogic::set() {
     output_bytes_.fill(0);
-    write_output_bytes();
     write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
         static_cast<bool>(Activate::ACTIVATE_GRIPPER));

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -135,7 +135,7 @@ uint8_t ProtocolLogic::get_raw_current() const {
 }
 
 void ProtocolLogic::read_input_bytes() {
-    input_bytes_ = communication_.get_input_bytes();
+    input_bytes_ = communication_.read();
 
     raw_status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
 
@@ -165,7 +165,7 @@ void ProtocolLogic::read_input_bytes() {
 }
 
 void ProtocolLogic::write_output_bytes() {
-    communication_.set_output_bytes(output_bytes_);
+    communication_.write(output_bytes_);
 }
 
 uint ProtocolLogic::bit_set_to(uint value, uint n, bool x) const {

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -1,7 +1,5 @@
 #include "robotiq_hande_driver/protocol_logic.hpp"
 
-#include <cstdio>
-
 namespace robotiq_hande_driver {
 
 ProtocolLogic::ProtocolLogic()

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -16,7 +16,7 @@ ProtocolLogic::ProtocolLogic()
       current_() {}
 
 void ProtocolLogic::refresh_registers() {
-    communication_.read_write_registers();
+    // communication_.read_write_registers();
 
     status_ = communication_.get_input_byte(InputBytes::GRIPPER_STATUS);
 

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -16,8 +16,6 @@ ProtocolLogic::ProtocolLogic()
       current_() {}
 
 void ProtocolLogic::refresh_registers() {
-    // communication_.read_write_registers();
-
     status_ = communication_.get_input_byte(InputBytes::GRIPPER_STATUS);
 
     activation_status_ =

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -135,7 +135,7 @@ uint8_t ProtocolLogic::get_raw_current() const {
 }
 
 void ProtocolLogic::read_input_bytes() {
-    input_bytes_ = communication_.read();
+    communication_.read(input_bytes_);
 
     raw_status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
 

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -15,34 +15,6 @@ ProtocolLogic::ProtocolLogic()
       position_(),
       current_() {}
 
-void ProtocolLogic::refresh_registers() {
-    // TODO get all input bytes at once
-    status_ = communication_.get_input_byte(InputBytes::GRIPPER_STATUS);
-
-    activation_status_ =
-        (ActivationStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTIVATION_STATUS))
-                           & ACTIVATION_STATUS_BITS);
-
-    action_status_ = (ActionStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTION_STATUS))
-                                    & ACTION_STATUS_BITS);
-
-    gripper_status_ =
-        (GripperStatus)((status_ >> static_cast<uint>(StatusPositionBit::GRIPPER_STATUS))
-                        & GRIPPER_STATUS_BITS);
-
-    object_detection_status_ =
-        (ObjectDetectionStatus)((status_
-                                 >> static_cast<uint>(StatusPositionBit::OBJECT_DETECTION_STATUS))
-                                & OBJECT_DETECTION_STATUS_BITS);
-
-    // TODO(issue#9) Read Hand-E fault status flags
-    fault_status_ = communication_.get_input_byte(InputBytes::FAULT_STATUS);
-
-    position_request_echo_ = communication_.get_input_byte(InputBytes::POSITION_REQUEST_ECHO);
-    position_ = communication_.get_input_byte(InputBytes::POSITION);
-    current_ = communication_.get_input_byte(InputBytes::CURRENT);
-}
-
 void ProtocolLogic::initialize(
     const std::string& tty_port,
     int baudrate,
@@ -70,26 +42,31 @@ void ProtocolLogic::cleanup() {
 }
 
 void ProtocolLogic::reset() {
-    communication_.clear_output_bytes();
-    communication_.write_action_bit(
+    output_bytes_.fill(0);
+    write_output_bytes();
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
         static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
+    write_output_bytes();
 }
 
 void ProtocolLogic::set() {
-    communication_.clear_output_bytes();
-    communication_.write_action_bit(
+    output_bytes_.fill(0);
+    write_output_bytes();
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
         static_cast<bool>(Activate::ACTIVATE_GRIPPER));
+    write_output_bytes();
 }
 
 void ProtocolLogic::auto_release() {
-    communication_.write_action_bit(
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE),
         static_cast<bool>(AutomaticRelease::EMERGENCY_AUTO_RELEASE));
-    communication_.write_action_bit(
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE_DIRECTION),
         static_cast<bool>(AutoReleaseDirection::OPENING));
+    write_output_bytes();
 }
 
 void ProtocolLogic::activate() {
@@ -102,16 +79,18 @@ void ProtocolLogic::deactivate() {
 }
 
 void ProtocolLogic::go_to(uint8_t position, uint8_t velocity, uint8_t force) {
-    communication_.write_action_bit(
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::GO_TO_REQ_POS));
-    communication_.set_output_byte(OutputBytes::POSITION_REQUEST, position);
-    communication_.set_output_byte(OutputBytes::SPEED, velocity);
-    communication_.set_output_byte(OutputBytes::FORCE, force);
+    set_output_byte(OutputBytes::POSITION_REQUEST, position);
+    set_output_byte(OutputBytes::SPEED, velocity);
+    set_output_byte(OutputBytes::FORCE, force);
+    write_output_bytes();
 }
 
 void ProtocolLogic::stop() {
-    communication_.write_action_bit(
+    write_action_bit(
         static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::STOP));
+    write_output_bytes();
 }
 
 bool ProtocolLogic::is_reset() const {
@@ -160,6 +139,63 @@ uint8_t ProtocolLogic::get_pos() const {
 
 uint8_t ProtocolLogic::get_current() const {
     return current_;
+}
+
+void ProtocolLogic::read_input_bytes() {
+    input_bytes_ = communication_.get_input_bytes();
+
+    // TODO extract this logic into a new struct
+    status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
+
+    activation_status_ =
+        (ActivationStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTIVATION_STATUS))
+                           & ACTIVATION_STATUS_BITS);
+
+    action_status_ = (ActionStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTION_STATUS))
+                                    & ACTION_STATUS_BITS);
+
+    gripper_status_ =
+        (GripperStatus)((status_ >> static_cast<uint>(StatusPositionBit::GRIPPER_STATUS))
+                        & GRIPPER_STATUS_BITS);
+
+    object_detection_status_ =
+        (ObjectDetectionStatus)((status_
+                                 >> static_cast<uint>(StatusPositionBit::OBJECT_DETECTION_STATUS))
+                                & OBJECT_DETECTION_STATUS_BITS);
+
+    // TODO(issue#9) Read Hand-E fault status flags
+    fault_status_ = get_input_byte(InputBytes::FAULT_STATUS);
+
+    position_request_echo_ = get_input_byte(InputBytes::POSITION_REQUEST_ECHO);
+    position_ = get_input_byte(InputBytes::POSITION);
+    current_ = get_input_byte(InputBytes::CURRENT);
+}
+
+void ProtocolLogic::write_output_bytes() {
+    communication_.set_output_bytes(output_bytes_);
+}
+
+uint ProtocolLogic::bit_set_to(uint value, uint n, bool x) const {
+    uint reset_n_bit = ~(1u << n);
+    uint set_n_bit = static_cast<uint>(x) << n;
+    return (value & reset_n_bit) | set_n_bit;
+}
+
+void ProtocolLogic::write_action_bit(uint8_t position_bit, bool value) {
+    auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST);
+    auto reg = output_bytes_[idx].load(std::memory_order_relaxed);
+    auto result = bit_set_to(reg, position_bit, value);
+    output_bytes_[idx] = result;
+}
+
+uint8_t ProtocolLogic::get_input_byte(InputBytes index) const {
+    auto idx = static_cast<uint>(index);
+    return input_bytes_[idx];
+}
+
+void ProtocolLogic::set_output_byte(OutputBytes index, uint8_t value) {
+    auto idx = static_cast<uint>(index);
+    output_bytes_[idx] = value;
 }
 
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -5,15 +5,15 @@
 namespace robotiq_hande_driver {
 
 ProtocolLogic::ProtocolLogic()
-    : status_{},
+    : raw_status_{},
       activation_status_{ActivationStatus::GRIPPER_RESET},
       action_status_{ActionStatus::STOPPED},
       gripper_status_{GripperStatus::NOT_USED},
       object_detection_status_{ObjectDetectionStatus::REQ_POS_NO_OBJECT},
-      fault_status_{},
-      position_request_echo_{},
-      position_{},
-      current_{} {}
+      raw_fault_status_{},
+      raw_position_request_{},
+      raw_position_{},
+      raw_current_{} {}
 
 void ProtocolLogic::initialize(const CommunicationConfig& cfg) {
     communication_.initialize(cfg);
@@ -24,10 +24,10 @@ void ProtocolLogic::configure() {
     action_status_ = ActionStatus::STOPPED;
     gripper_status_ = GripperStatus::NOT_USED;
     object_detection_status_ = ObjectDetectionStatus::REQ_POS_NO_OBJECT;
-    fault_status_ = 0;
-    position_request_echo_ = 0;
-    position_ = 0;
-    current_ = 0;
+    raw_fault_status_ = 0;
+    raw_position_request_ = 0;
+    raw_position_ = 0;
+    raw_current_ = 0;
 
     communication_.configure();
 }
@@ -111,11 +111,11 @@ bool ProtocolLogic::is_stopped() const {
 }
 
 bool ProtocolLogic::is_closed() const {
-    return position_ >= GRIPPER_POSITION_OPENED_THRESHOLD;
+    return raw_position_ >= GRIPPER_POSITION_OPENED_THRESHOLD;
 }
 
 bool ProtocolLogic::is_opened() const {
-    return position_ <= GRIPPER_POSITION_CLOSED_THRESHOLD;
+    return raw_position_ <= GRIPPER_POSITION_CLOSED_THRESHOLD;
 }
 
 bool ProtocolLogic::obj_detected() const {
@@ -124,45 +124,46 @@ bool ProtocolLogic::obj_detected() const {
         || object_detection_status_ == ObjectDetectionStatus::STOPPED_CLOSING_DETECTED);
 }
 
-uint8_t ProtocolLogic::get_reg_pos() const {
-    return position_request_echo_;
+uint8_t ProtocolLogic::get_raw_requested_pos() const {
+    return raw_position_request_;
 }
 
-uint8_t ProtocolLogic::get_pos() const {
-    return position_;
+uint8_t ProtocolLogic::get_raw_pos() const {
+    return raw_position_;
 }
 
-uint8_t ProtocolLogic::get_current() const {
-    return current_;
+uint8_t ProtocolLogic::get_raw_current() const {
+    return raw_current_;
 }
 
 void ProtocolLogic::read_input_bytes() {
     input_bytes_ = communication_.get_input_bytes();
 
-    status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
+    raw_status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
 
     activation_status_ =
-        (ActivationStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTIVATION_STATUS))
+        (ActivationStatus)((raw_status_ >> static_cast<uint>(StatusPositionBit::ACTIVATION_STATUS))
                            & ACTIVATION_STATUS_BITS);
 
-    action_status_ = (ActionStatus)((status_ >> static_cast<uint>(StatusPositionBit::ACTION_STATUS))
-                                    & ACTION_STATUS_BITS);
+    action_status_ =
+        (ActionStatus)((raw_status_ >> static_cast<uint>(StatusPositionBit::ACTION_STATUS))
+                       & ACTION_STATUS_BITS);
 
     gripper_status_ =
-        (GripperStatus)((status_ >> static_cast<uint>(StatusPositionBit::GRIPPER_STATUS))
+        (GripperStatus)((raw_status_ >> static_cast<uint>(StatusPositionBit::GRIPPER_STATUS))
                         & GRIPPER_STATUS_BITS);
 
     object_detection_status_ =
-        (ObjectDetectionStatus)((status_
+        (ObjectDetectionStatus)((raw_status_
                                  >> static_cast<uint>(StatusPositionBit::OBJECT_DETECTION_STATUS))
                                 & OBJECT_DETECTION_STATUS_BITS);
 
     // TODO(issue#9) Read Hand-E fault status flags
-    fault_status_ = get_input_byte(InputBytes::FAULT_STATUS);
+    raw_fault_status_ = get_input_byte(InputBytes::FAULT_STATUS);
 
-    position_request_echo_ = get_input_byte(InputBytes::POSITION_REQUEST_ECHO);
-    position_ = get_input_byte(InputBytes::POSITION);
-    current_ = get_input_byte(InputBytes::CURRENT);
+    raw_position_request_ = get_input_byte(InputBytes::POSITION_REQUEST_ECHO);
+    raw_position_ = get_input_byte(InputBytes::POSITION);
+    raw_current_ = get_input_byte(InputBytes::CURRENT);
 }
 
 void ProtocolLogic::write_output_bytes() {

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -16,6 +16,7 @@ ProtocolLogic::ProtocolLogic()
       current_() {}
 
 void ProtocolLogic::refresh_registers() {
+    // TODO get all input bytes at once
     status_ = communication_.get_input_byte(InputBytes::GRIPPER_STATUS);
 
     activation_status_ =
@@ -143,7 +144,7 @@ bool ProtocolLogic::is_opened() const {
     return position_ <= GRIPPER_POSITION_CLOSED_THRESHOLD;
 }
 
-bool ProtocolLogic::obj_detected() {
+bool ProtocolLogic::obj_detected() const {
     return (
         object_detection_status_ == ObjectDetectionStatus::STOPPED_OPENING_DETECTED
         || object_detection_status_ == ObjectDetectionStatus::STOPPED_CLOSING_DETECTED);

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -5,24 +5,18 @@
 namespace robotiq_hande_driver {
 
 ProtocolLogic::ProtocolLogic()
-    : status_(),
-      activation_status_(ActivationStatus::GRIPPER_RESET),
-      action_status_(ActionStatus::STOPPED),
-      gripper_status_(GripperStatus::NOT_USED),
-      object_detection_status_(ObjectDetectionStatus::REQ_POS_NO_OBJECT),
-      fault_status_(),
-      position_request_echo_(),
-      position_(),
-      current_() {}
+    : status_{},
+      activation_status_{ActivationStatus::GRIPPER_RESET},
+      action_status_{ActionStatus::STOPPED},
+      gripper_status_{GripperStatus::NOT_USED},
+      object_detection_status_{ObjectDetectionStatus::REQ_POS_NO_OBJECT},
+      fault_status_{},
+      position_request_echo_{},
+      position_{},
+      current_{} {}
 
-void ProtocolLogic::initialize(
-    const std::string& tty_port,
-    int baudrate,
-    char parity,
-    int data_bits,
-    int stop_bit,
-    int slave_id) {
-    communication_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
+void ProtocolLogic::initialize(const CommunicationConfig& cfg) {
+    communication_.initialize(cfg);
 }
 
 int ProtocolLogic::configure() {
@@ -144,7 +138,6 @@ uint8_t ProtocolLogic::get_current() const {
 void ProtocolLogic::read_input_bytes() {
     input_bytes_ = communication_.get_input_bytes();
 
-    // TODO extract this logic into a new struct
     status_ = get_input_byte(InputBytes::GRIPPER_STATUS);
 
     activation_status_ =

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -41,4 +41,124 @@ void ProtocolLogic::refresh_registers() {
     position_ = communication_.get_input_byte(InputBytes::POSITION);
     current_ = communication_.get_input_byte(InputBytes::CURRENT);
 }
+
+void ProtocolLogic::initialize(
+    const std::string& tty_port,
+    int baudrate,
+    char parity,
+    int data_bits,
+    int stop_bit,
+    int slave_id) {
+    communication_.initialize(tty_port, baudrate, parity, data_bits, stop_bit, slave_id);
+}
+
+int ProtocolLogic::configure() {
+    activation_status_ = ActivationStatus::GRIPPER_RESET;
+    action_status_ = ActionStatus::STOPPED;
+    gripper_status_ = GripperStatus::NOT_USED;
+    object_detection_status_ = ObjectDetectionStatus::REQ_POS_NO_OBJECT;
+    fault_status_ = 0;
+    position_request_echo_ = 0;
+    position_ = 0;
+    current_ = 0;
+    return communication_.configure();
+}
+
+void ProtocolLogic::cleanup() {
+    communication_.cleanup();
+}
+
+void ProtocolLogic::reset() {
+    communication_.clear_output_bytes();
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
+        static_cast<bool>(Activate::DEACTIVATE_GRIPPER));
+}
+
+void ProtocolLogic::set() {
+    communication_.clear_output_bytes();
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::ACTIVATE),
+        static_cast<bool>(Activate::ACTIVATE_GRIPPER));
+}
+
+void ProtocolLogic::auto_release() {
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE),
+        static_cast<bool>(AutomaticRelease::EMERGENCY_AUTO_RELEASE));
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::AUTOMATIC_RELEASE_DIRECTION),
+        static_cast<bool>(AutoReleaseDirection::OPENING));
+}
+
+void ProtocolLogic::activate() {
+    reset();
+    set();
+}
+
+void ProtocolLogic::deactivate() {
+    reset();
+}
+
+void ProtocolLogic::go_to(uint8_t position, uint8_t velocity, uint8_t force) {
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::GO_TO_REQ_POS));
+    communication_.set_output_byte(OutputBytes::POSITION_REQUEST, position);
+    communication_.set_output_byte(OutputBytes::SPEED, velocity);
+    communication_.set_output_byte(OutputBytes::FORCE, force);
+}
+
+void ProtocolLogic::stop() {
+    communication_.write_action_bit(
+        static_cast<uint>(ActionRequestPositionBit::GO_TO), static_cast<bool>(GoTo::STOP));
+}
+
+bool ProtocolLogic::is_reset() const {
+    return (
+        gripper_status_ == GripperStatus::GRIPPER_IN_RESET
+        && activation_status_ == ActivationStatus::GRIPPER_RESET);
+}
+
+bool ProtocolLogic::is_ready() const {
+    return (
+        gripper_status_ == GripperStatus::ACTIVATION_COMPLETE
+        && activation_status_ == ActivationStatus::GRIPPER_ACTIVATION);
+}
+
+bool ProtocolLogic::is_moving() const {
+    return (
+        action_status_ == ActionStatus::GO_TO_POSITION_REQUEST
+        && object_detection_status_ == ObjectDetectionStatus::MOTION_NO_OBJECT);
+}
+
+bool ProtocolLogic::is_stopped() const {
+    return object_detection_status_ != ObjectDetectionStatus::MOTION_NO_OBJECT;
+}
+
+bool ProtocolLogic::is_closed() const {
+    return position_ >= GRIPPER_POSITION_OPENED_THRESHOLD;
+}
+
+bool ProtocolLogic::is_opened() const {
+    return position_ <= GRIPPER_POSITION_CLOSED_THRESHOLD;
+}
+
+bool ProtocolLogic::obj_detected() {
+    return (
+        object_detection_status_ == ObjectDetectionStatus::STOPPED_OPENING_DETECTED
+        || object_detection_status_ == ObjectDetectionStatus::STOPPED_CLOSING_DETECTED);
+}
+
+uint8_t ProtocolLogic::get_reg_pos() const {
+    return position_request_echo_;
+}
+
+uint8_t ProtocolLogic::get_pos() const {
+    return position_;
+}
+
+uint8_t ProtocolLogic::get_current() const {
+    return current_;
+}
+
 }  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -183,7 +183,7 @@ uint ProtocolLogic::bit_set_to(uint value, uint n, bool x) const {
 
 void ProtocolLogic::write_action_bit(uint8_t position_bit, bool value) {
     auto idx = static_cast<uint>(OutputBytes::ACTION_REQUEST);
-    auto reg = output_bytes_[idx].load(std::memory_order_relaxed);
+    auto reg = output_bytes_[idx];
     auto result = bit_set_to(reg, position_bit, value);
     output_bytes_[idx] = result;
 }

--- a/robotiq_hande_driver/hardware/src/protocol_logic.cpp
+++ b/robotiq_hande_driver/hardware/src/protocol_logic.cpp
@@ -19,7 +19,7 @@ void ProtocolLogic::initialize(const CommunicationConfig& cfg) {
     communication_.initialize(cfg);
 }
 
-int ProtocolLogic::configure() {
+void ProtocolLogic::configure() {
     activation_status_ = ActivationStatus::GRIPPER_RESET;
     action_status_ = ActionStatus::STOPPED;
     gripper_status_ = GripperStatus::NOT_USED;
@@ -28,7 +28,8 @@ int ProtocolLogic::configure() {
     position_request_echo_ = 0;
     position_ = 0;
     current_ = 0;
-    return communication_.configure();
+
+    communication_.configure();
 }
 
 void ProtocolLogic::cleanup() {

--- a/robotiq_hande_driver/hardware/src/socat_manager.cpp
+++ b/robotiq_hande_driver/hardware/src/socat_manager.cpp
@@ -1,5 +1,7 @@
 #include "robotiq_hande_driver/socat_manager.hpp"
 
+#include <stdexcept>
+
 namespace robotiq_hande_driver {
 
 SocatManager::SocatManager(const std::string& host, int port, const std::string& tty_path)
@@ -16,8 +18,8 @@ void SocatManager::start() {
     // Child process code
     if(socat_pid_ == 0) {
         // Child process - execute socat
-        std::string tcp_endpoint = "tcp:" + host_ + ":" + std::to_string(port_);
         std::string pty_endpoint = "pty,link=" + tty_path_ + ",raw,ignoreeof,waitslave";
+        std::string tcp_endpoint = "tcp:" + host_ + ":" + std::to_string(port_);
 
         char* args[] = {
             const_cast<char*>("socat"),
@@ -38,7 +40,7 @@ void SocatManager::start() {
     int status;
     if(waitpid(socat_pid_, &status, WNOHANG) == 0) return;
 
-    throw RuntimeError("Failed to start the forked process for virtual serial port (socat).");
+    throw std::runtime_error("Failed to start the forked process for virtual serial port (socat).");
 }
 
 void SocatManager::stop() {

--- a/robotiq_hande_driver/hardware/src/socat_manager.cpp
+++ b/robotiq_hande_driver/hardware/src/socat_manager.cpp
@@ -1,5 +1,6 @@
 #include "robotiq_hande_driver/socat_manager.hpp"
 
+#include <iostream>
 #include <stdexcept>
 
 namespace robotiq_hande_driver {
@@ -34,7 +35,6 @@ void SocatManager::start() {
 
     // Parent process code
     started_ = true;
-    std::this_thread::sleep_for(WAIT_FOR_SOCAT);
 
     // Check if process is still alive
     int status;

--- a/robotiq_hande_driver/hardware/src/socat_manager.cpp
+++ b/robotiq_hande_driver/hardware/src/socat_manager.cpp
@@ -1,0 +1,64 @@
+#include "robotiq_hande_driver/socat_manager.hpp"
+
+namespace robotiq_hande_driver {
+
+SocatManager::SocatManager(const std::string& host, int port, const std::string& tty_path)
+    : host_{host}, port_{port}, tty_path_{tty_path} {}
+
+SocatManager::~SocatManager() {
+    stop();
+}
+
+void SocatManager::start() {
+    // Fork to create child process
+    socat_pid_ = fork();
+
+    // Child process code
+    if(socat_pid_ == 0) {
+        // Child process - execute socat
+        std::string tcp_endpoint = "tcp:" + host_ + ":" + std::to_string(port_);
+        std::string pty_endpoint = "pty,link=" + tty_path_ + ",raw,ignoreeof,waitslave";
+
+        char* args[] = {
+            const_cast<char*>("socat"),
+            const_cast<char*>(pty_endpoint.c_str()),
+            const_cast<char*>(tcp_endpoint.c_str()),
+            nullptr};
+
+        execvp("socat", args);
+        perror("execvp socat failed");
+        exit(1);
+    }
+
+    // Parent process code
+    started_ = true;
+    std::this_thread::sleep_for(WAIT_FOR_SOCAT);
+
+    // Check if process is still alive
+    int status;
+    if(waitpid(socat_pid_, &status, WNOHANG) == 0) return;
+
+    throw RuntimeError("Failed to start the forked process for virtual serial port (socat).");
+}
+
+void SocatManager::stop() {
+    if(!started_ || socat_pid_ == -1) return;
+
+    kill(socat_pid_, SIGTERM);
+
+    int status;
+    waitpid(socat_pid_, &status, 0);
+
+    started_ = false;
+    unlink(tty_path_.c_str());
+    return;
+}
+
+bool SocatManager::is_alive() const {
+    if(!started_) return false;
+
+    int status;
+    return waitpid(socat_pid_, &status, WNOHANG) == 0;
+}
+
+}  // namespace robotiq_hande_driver

--- a/robotiq_hande_driver/hardware/src/socat_manager.cpp
+++ b/robotiq_hande_driver/hardware/src/socat_manager.cpp
@@ -1,6 +1,5 @@
 #include "robotiq_hande_driver/socat_manager.hpp"
 
-#include <iostream>
 #include <stdexcept>
 
 namespace robotiq_hande_driver {

--- a/robotiq_hande_driver/package.xml
+++ b/robotiq_hande_driver/package.xml
@@ -24,6 +24,8 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>robotiq_hande_description</depend>
 
+  <exec_depend>socat</exec_depend>
+
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/robotiq_hande_driver/test/communication_test.cpp
+++ b/robotiq_hande_driver/test/communication_test.cpp
@@ -12,8 +12,8 @@ constexpr auto DEBUG_MODBUS = true;
 
 constexpr uint8_t SERVER_ID = 0x09;
 
-constexpr uint16_t GRIPPER_OUTPUT_FIRST_REG = 0x07D0;
-constexpr uint16_t GRIPPER_INPUT_FIRST_REG = 0x03E8;
+constexpr uint16_t SERIAL_OUTPUT_FIRST_REG = 0x07D0;
+constexpr uint16_t SERIAL_INPUT_FIRST_REG = 0x03E8;
 constexpr uint8_t READ_WRITE_REG_LENGTH = 3;
 
 constexpr uint16_t GRIPPER_FLAGS_DEACTIVATE = 0x0000;
@@ -36,7 +36,7 @@ void test_connection(modbus_t* ctx) {
     uint16_t tab_reg[REGISTER_READ_LENGTH];
 
     // Read 5 registers from the address 0
-    modbus_read_registers(ctx, GRIPPER_OUTPUT_FIRST_REG, REGISTER_READ_LENGTH, tab_reg);
+    modbus_read_registers(ctx, SERIAL_OUTPUT_FIRST_REG, REGISTER_READ_LENGTH, tab_reg);
 
     printf(
         "Status: %.4X %.4X %.4X %.4X %.4X %.4X\n",
@@ -53,26 +53,26 @@ void activate(modbus_t* ctx) {
     uint16_t activation_request_register_reset[READ_WRITE_REG_LENGTH] = {
         GRIPPER_FLAGS_DEACTIVATE, 0x0000, 0x0000};
     modbus_write_registers(
-        ctx, GRIPPER_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_request_register_reset);
+        ctx, SERIAL_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_request_register_reset);
 
     uint16_t activation_request_register_set[READ_WRITE_REG_LENGTH] = {
         GRIPPER_FLAGS_ACTIVATE, 0x0000, 0x0000};
     modbus_write_registers(
-        ctx, GRIPPER_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_request_register_set);
+        ctx, SERIAL_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_request_register_set);
 }
 
 void wait_activation_complete(modbus_t* ctx) {
     printf("Step: Read Gripper status until the activation is completed\n");
     uint16_t activation_status[READ_WRITE_REG_LENGTH] = {};
 
-    modbus_read_registers(ctx, GRIPPER_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_status);
+    modbus_read_registers(ctx, SERIAL_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, activation_status);
 
     while(activation_status[0] != GRIPPER_FLAGS_ACTIVATED) {
         printf(
             "Gripper not yet activated: %.4X vs. %.4X\n",
             activation_status[0],
             GRIPPER_FLAGS_ACTIVATED);
-        modbus_read_registers(ctx, GRIPPER_OUTPUT_FIRST_REG, 1, activation_status);
+        modbus_read_registers(ctx, SERIAL_OUTPUT_FIRST_REG, 1, activation_status);
     }
 }
 
@@ -81,7 +81,7 @@ void close_gripper(modbus_t* ctx) {
     uint16_t close_gripper_request_register[READ_WRITE_REG_LENGTH] = {
         GRIPPER_FLAGS_MOVE, GRIPPER_CLOSED, FULL_SPEED_FORCE};
     modbus_write_registers(
-        ctx, GRIPPER_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, close_gripper_request_register);
+        ctx, SERIAL_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, close_gripper_request_register);
 }
 
 void open_gripper(modbus_t* ctx) {
@@ -89,7 +89,7 @@ void open_gripper(modbus_t* ctx) {
     uint16_t open_gripper_request_register[READ_WRITE_REG_LENGTH] = {
         GRIPPER_FLAGS_MOVE, GRIPPER_OPENED, FULL_SPEED_FORCE};
     modbus_write_registers(
-        ctx, GRIPPER_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, open_gripper_request_register);
+        ctx, SERIAL_INPUT_FIRST_REG, READ_WRITE_REG_LENGTH, open_gripper_request_register);
 }
 
 void wait_movement_complete(modbus_t* ctx) {
@@ -97,7 +97,7 @@ void wait_movement_complete(modbus_t* ctx) {
     uint16_t gripper_status_movement[READ_WRITE_REG_LENGTH] = {};
 
     modbus_read_registers(
-        ctx, GRIPPER_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, gripper_status_movement);
+        ctx, SERIAL_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, gripper_status_movement);
 
     while(gripper_status_movement[0] != GRIPPER_FLAGS_CLOSED
           && gripper_status_movement[0] != GRIPPER_FLAGS_NO_OBJECT) {
@@ -107,7 +107,7 @@ void wait_movement_complete(modbus_t* ctx) {
             GRIPPER_FLAGS_NO_OBJECT,
             GRIPPER_FLAGS_CLOSED);
         modbus_read_registers(
-            ctx, GRIPPER_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, gripper_status_movement);
+            ctx, SERIAL_OUTPUT_FIRST_REG, READ_WRITE_REG_LENGTH, gripper_status_movement);
         sleep_100ms();
     }
 }

--- a/robotiq_hande_driver/test/test_load_hw_interface.cpp
+++ b/robotiq_hande_driver/test/test_load_hw_interface.cpp
@@ -35,6 +35,9 @@ class TestHWInterface : public ::testing::Test {
                     <param name="stop_bit">1</param>
                     <param name="slave_id">9</param>
                     <param name="frequency_hz">10</param>
+                    <param name="create_socat_tty">false</param>
+                    <param name="ip_adress">127.0.0.1</param>
+                    <param name="port">8888</param>
                 </hardware>
                 <joint name="joint1">
                     <command_interface name="position"/>

--- a/robotiq_hande_driver/test/test_load_hw_interface.cpp
+++ b/robotiq_hande_driver/test/test_load_hw_interface.cpp
@@ -34,6 +34,7 @@ class TestHWInterface : public ::testing::Test {
                     <param name="data_bits">8</param>
                     <param name="stop_bit">1</param>
                     <param name="slave_id">9</param>
+                    <param name="frequency_hz">10</param>
                 </hardware>
                 <joint name="joint1">
                     <command_interface name="position"/>

--- a/robotiq_hande_driver/test/test_load_hw_interface.cpp
+++ b/robotiq_hande_driver/test/test_load_hw_interface.cpp
@@ -28,7 +28,7 @@ class TestHWInterface : public ::testing::Test {
                     <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
                     <param name="grip_pos_min">0.0</param>
                     <param name="grip_pos_max" default="0.025</param>
-                    <param name="tty">/tmp/ttyUR</param>
+                    <param name="tty_port">/tmp/ttyUR</param>
                     <param name="baudrate" >115200</param>
                     <param name="parity">N</param>
                     <param name="data_bits">8</param>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
After an attempt of introduction of a separate thread for the modbus communication in #19, more changes in the codebase were needed.
This resulted in a **_major refactor_** of the codebase.

* It fixes the bug in the `aegis_ros` repository: https://github.com/AGH-CEAI/aegis_ros/issues/38
* The issue with the `ros2_control_examples` warnings is not showing anymore, so it was possible to to re-enable the `-Werror` compile flag #5 .
* The new thread with mutexes are placed in the HW interface.
* Introducing `SocatManager` - the `robotiq_hande_driver` can now manage the external `socat` process and spawn it at will (via new boolean URDF param called `create_socat_tty`).
* Improved logging with colors, new `namespace colour` in a brand new `utils.hpp`.
* Cleanup of the doc strings.
* Renamed `application.hpp/cpp` into `hande_gripper.hpp/cpp`.
* Changed plain arrays `uint8_t bytes_[]` into `std::array<uint8_t, *>`.
* Moved all logic from the `communication.cpp/hpp` to `protocol_logic.cpp/hpp`.
* Moved all non-trivial definitions from `*.hpp`s to `*.cpp`s.
* Moved from C-like functions to C++ ones (e.g. to `chrono` and `thread` instead of `usleep()`).
* Encapsulated whole `Communication` config into `CommunicationConfig` struct.
* Fixed typos with wrong values in  `GRIPPER_OUTPUT_FIRST_REG`  and `GRIPPER_INPUT_FIRST_REG`.
* Introduced 4 new params for URDFs:
    * `frequency_hz` (int) to control the ammount of sleep rate in new thread
    * `create_socat_tty` (bool) to create a virtual serial port,
    * `ip_adress` and `port` to configure the creation of virtual serial port with `socat`,
*  renamed `tty` param to `tty_port` for better clarity.

>[!NOTE]
> For this PR we should use the **squash marge** option

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* To fix the integration with the UR's RTDE protocol.

## Related PRs
* https://github.com/AGH-CEAI/aegis_ros/pull/49
* https://github.com/AGH-CEAI/robotiq_hande_description/pull/14

<!--- ## Screenshots (if appropriate): -->

## Related issues
* Closes AGH-CEAI/aegis_ros#38
* Closes #5
* Investigated: #22 
* Previous PR: #19 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Tested manually on the Aegis robot, on the geonosis PC, with the whole `aegis_ros` stack.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869972nfu](https://app.clickup.com/t/869972nfu)
