### PR TITLE
Wrong type in `export_command_interfaces()`

### DIFF
--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [PR-25](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/25) - Fixed wrong type for the force command interface (from `HW_IF_POSITION` to `HW_IF_EFFORT`).
 * [PR-21](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/21) - Fixed:
   * Fixed integration with - UR's RTDE communication protocol ([aegis_ros#38](https://github.com/AGH-CEAI/aegis_ros/issues/38)).
   * Re-enabled the `-Werror` flag #5.

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -2,14 +2,9 @@ cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_driver)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  # If you got problems with ROS Humble's bundled gmock version:
-  # a) change the compiler to clang >= 14.0.0
-  # b) add flag `-Wno-deprecated-copy`
-  add_compile_options(
-    -Wall
-    -Wextra
-    -Wpedantic
-    -Werror)
+  # If you got problems with ROS Humble's bundled gmock version: a) change the compiler to clang >=
+  # 14.0.0 b) add flag `-Wno-deprecated-copy`
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 include(FindPkgConfig)

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -2,13 +2,14 @@ cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_driver)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  # Flag `-Wno-deprecated-copy` is related to the ROS Humble's bundled gmock version.
+  # If you got problems with ROS Humble's bundled gmock version:
+  # a) change the compiler to clang >= 14.0.0
+  # b) add flag `-Wno-deprecated-copy`
   add_compile_options(
     -Wall
     -Wextra
     -Wpedantic
-    -Werror
-    -Wno-deprecated-copy)
+    -Werror)
 endif()
 
 include(FindPkgConfig)

--- a/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
+++ b/robotiq_hande_driver/hardware/src/hande_hardware_interface.cpp
@@ -172,7 +172,7 @@ std::vector<HWI::CommandInterface> RobotiqHandeHardwareInterface::export_command
         hardware_interface::HW_IF_POSITION,
         &cmd_position_));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[LEFT_FINGER_JOINT_ID].name, hardware_interface::HW_IF_POSITION, &cmd_force_));
+        info_.joints[LEFT_FINGER_JOINT_ID].name, hardware_interface::HW_IF_EFFORT, &cmd_force_));
 
     return command_interfaces;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
There was a small typo ino the `export_command_interfaces()` method for the force: it was registers as `HW_IF_POSITION` instead of `HW_IF_EFFORT`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Working on #18 revealed a typo in our code.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* By compiling.
* Further test will be done before the release `0.2.0`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [8699zuex5](https://app.clickup.com/t/8699zuex5)
