### PR TITLE
Fix missing ros2_control_test_assets dependency 

### DIFF
--- a/robotiq_hande_driver/CHANGELOG.md
+++ b/robotiq_hande_driver/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* [PR-33](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/33) - Fixed missing ros2_control_test_assets dependency in CMakeLists.txt that causes build failures after ROS2 Humble package updates.
+
 ### Security
 
 ## [0.2.0] - 2025-08-25

--- a/robotiq_hande_driver/CMakeLists.txt
+++ b/robotiq_hande_driver/CMakeLists.txt
@@ -61,10 +61,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   # find_package(ament_cmake_pytest REQUIRED)
   find_package(hardware_interface REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
 
   ament_add_gmock(test_load_hw_interface test/test_load_hw_interface.cpp)
   target_link_libraries(test_load_hw_interface ${PROJECT_NAME})
-
+  ament_target_dependencies(test_load_hw_interface ros2_control_test_assets)
+  
   # TODO(issue#8) Build the communication_test only with BUILD_TESTING flag
   # ament_add_gmock(application_test test/application_test.cpp )
   # target_link_libraries(application_test ${PROJECT_NAME})


### PR DESCRIPTION
## Description
Fix missing ros2_control_test_assets dependency in CMakeLists.txt that causes build failures after ROS2 Humble package updates.

This is a small build fix (two lines in CMakeLists.txt). Submitting in case it's useful , feel free to merge, adjust, or close if you'd prefer to handle differently.

## Motivation and context
After recent ROS2 Humble ros2_control package updates, the build fails with:
  `fatal error: ros2_control_test_assets/components_urdfs.hpp: No such file or directory`
  
**Solution**: Added the missing find_package and ament_target_dependencies calls for the test target.

<!--- ## Screenshots (if appropriate): -->

## How has this been tested?
  - Environment: Ubuntu 22.04, ROS2 Humble
  - Before fix : Build failed with missing header error 
  - After fix: Build succeeds without errors
  - Command: `colcon build --packages-select robotiq_hande_driver`
  - Result: Package builds successfully




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [ ] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ ] All automated checks have passed.

---
Clickup task: [hash](link)
